### PR TITLE
- Added the set request id functionality for all entry points

### DIFF
--- a/src/main/java/com/appdirect/sdk/appmarket/events/AppmarketEventController.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/events/AppmarketEventController.java
@@ -22,7 +22,6 @@ import javax.servlet.http.HttpServletRequest;
 
 import lombok.extern.slf4j.Slf4j;
 
-import org.slf4j.MDC;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -37,8 +36,6 @@ class AppmarketEventController {
 
 	private final AppmarketEventService appmarketEventService;
 	private final OAuthKeyExtractor keyExtractor;
-	public static final String REQUEST_ID_HEADER = "x-request-id";
-	public static final String MDC_REQUEST_ID_KEY = "requestId";
 
 	AppmarketEventController(AppmarketEventService appmarketEventService, OAuthKeyExtractor keyExtractor) {
 		this.appmarketEventService = appmarketEventService;
@@ -54,7 +51,6 @@ class AppmarketEventController {
 	@RequestMapping(method = GET, value = "/api/v1/integration/processEvent", produces = APPLICATION_JSON_VALUE)
 	public ResponseEntity<APIResult> processEvent(HttpServletRequest request, @RequestParam("eventUrl") String eventUrl) {
 
-		storeRequestIdInLogContext(request);
 		String keyUsedToSignRequest = keyExtractor.extractFrom(request);
 		log.info("eventUrl={} signed with consumerKey={}", eventUrl, keyUsedToSignRequest);
 
@@ -62,11 +58,6 @@ class AppmarketEventController {
 
 		log.info("apiResult={}", result);
 		return new ResponseEntity<>(result, httpStatusOf(result));
-	}
-
-	private void storeRequestIdInLogContext(HttpServletRequest request) {
-		String header = request.getHeader(REQUEST_ID_HEADER);
-		MDC.put(MDC_REQUEST_ID_KEY, header);
 	}
 
 	private EventHandlingContext eventExecutionContext(HttpServletRequest request, String keyUsedToSignRequest) {

--- a/src/main/java/com/appdirect/sdk/web/oauth/RequestIdFilter.java
+++ b/src/main/java/com/appdirect/sdk/web/oauth/RequestIdFilter.java
@@ -1,0 +1,38 @@
+package com.appdirect.sdk.web.oauth;
+
+import java.io.IOException;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+
+import org.slf4j.MDC;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+public class RequestIdFilter implements Filter {
+	public static final String REQUEST_ID_HEADER = "x-request-id";
+	public static final String MDC_REQUEST_ID_KEY = "requestId";
+
+	@Override
+	public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+		HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.getRequestAttributes()).getRequest();
+		String header = request.getHeader(REQUEST_ID_HEADER);
+		MDC.put(MDC_REQUEST_ID_KEY, header);
+		filterChain.doFilter(servletRequest, servletResponse);
+	}
+
+	@Override
+	public void init(FilterConfig filterConfig) throws ServletException {
+		// Do nothing
+	}
+
+	@Override
+	public void destroy() {
+		// Do nothing
+	}
+}

--- a/src/main/java/com/appdirect/sdk/web/oauth/SecurityConfiguration.java
+++ b/src/main/java/com/appdirect/sdk/web/oauth/SecurityConfiguration.java
@@ -70,6 +70,11 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 		return filter;
 	}
 
+	@Bean
+	public RequestIdFilter requestIdFilter() {
+		return new RequestIdFilter();
+	}
+
 	@Override
 	protected void configure(HttpSecurity http) throws Exception {
 		http
@@ -83,6 +88,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 				.csrf().disable()
 				.authorizeRequests().anyRequest().authenticated()
 					.and()
-				.addFilterBefore(oAuthSignatureCheckingFilter(), UsernamePasswordAuthenticationFilter.class);
+				.addFilterBefore(oAuthSignatureCheckingFilter(), UsernamePasswordAuthenticationFilter.class)
+				.addFilterBefore(requestIdFilter(), OAuthSignatureCheckingFilter.class);
 	}
 }

--- a/src/test/java/com/appdirect/sdk/appmarket/events/AppmarketEventControllerTest.java
+++ b/src/test/java/com/appdirect/sdk/appmarket/events/AppmarketEventControllerTest.java
@@ -14,8 +14,6 @@
 package com.appdirect.sdk.appmarket.events;
 
 import static com.appdirect.sdk.appmarket.events.APIResult.success;
-import static com.appdirect.sdk.appmarket.events.AppmarketEventController.MDC_REQUEST_ID_KEY;
-import static com.appdirect.sdk.appmarket.events.AppmarketEventController.REQUEST_ID_HEADER;
 import static com.appdirect.sdk.appmarket.events.EventHandlingContexts.eventContext;
 import static com.appdirect.sdk.support.QueryParameters.oneQueryParam;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -33,7 +31,6 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.slf4j.MDC;
 import org.springframework.http.ResponseEntity;
 
 import com.appdirect.sdk.web.oauth.OAuthKeyExtractor;
@@ -76,19 +73,6 @@ public class AppmarketEventControllerTest {
 
 		assertThat(response.getBody()).isEqualTo(aHugeSuccess);
 		assertThat(response.getStatusCode()).isEqualTo(OK);
-	}
-
-	@Test
-	public void processEvent_includeXRequestIdHeaderInMDC_whenAvailable() throws Exception {
-		//Given
-		String uuid = "some_uuid";
-		HttpServletRequest request = aRequestContainingHeader(REQUEST_ID_HEADER, uuid);
-
-		//When
-		controller.processEvent(request, "some-event-url");
-
-		//Then
-		assertThat(MDC.get(MDC_REQUEST_ID_KEY)).isEqualTo(uuid);
 	}
 
 	private HttpServletRequest aRequestContainingHeader(String key, String value) {

--- a/src/test/java/com/appdirect/sdk/appmarket/validation/AppmarketOrderValidationControllerTest.java
+++ b/src/test/java/com/appdirect/sdk/appmarket/validation/AppmarketOrderValidationControllerTest.java
@@ -29,15 +29,11 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.util.MultiValueMap;
 
-import com.appdirect.sdk.appmarket.validation.AppmarketOrderValidationController;
-import com.appdirect.sdk.appmarket.validation.AppmarketOrderValidationHandler;
-
 @RunWith(MockitoJUnitRunner.class)
 public class AppmarketOrderValidationControllerTest {
 
 	@Mock
 	private AppmarketOrderValidationHandler mockValidationHandler;
-
 	private AppmarketOrderValidationController tested;
 
 	@Before

--- a/src/test/java/com/appdirect/sdk/feature/RequestIdFilterIntegrationTest.java
+++ b/src/test/java/com/appdirect/sdk/feature/RequestIdFilterIntegrationTest.java
@@ -1,0 +1,60 @@
+package com.appdirect.sdk.feature;
+
+import static com.appdirect.sdk.web.oauth.RequestIdFilter.REQUEST_ID_HEADER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+import static org.springframework.util.SocketUtils.findAvailableTcpPort;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.util.EntityUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.context.embedded.LocalServerPort;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.appdirect.sdk.feature.sample_connector.minimal.MinimalConnector;
+import com.appdirect.sdk.support.FakeAppmarket;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = MinimalConnector.class, webEnvironment = RANDOM_PORT)
+public class RequestIdFilterIntegrationTest {
+
+	@LocalServerPort
+	private int localConnectorPort;
+	private FakeAppmarket fakeAppmarket;
+
+	@Before
+	public void setUp() throws Exception {
+		fakeAppmarket = FakeAppmarket.create(findAvailableTcpPort(), "isv-key", "isv-secret").start();
+	}
+
+	@After
+	public void stop() throws Exception {
+		fakeAppmarket.stop();
+	}
+
+	@Test
+	public void requestIdShouldBeAddedProperly() throws Exception {
+		//Given
+		String requestId = "requestId";
+
+		//When
+		HttpResponse response = fakeAppmarket.callDummyRestController(dummyEndpointUrl(), new BasicHeader(REQUEST_ID_HEADER, requestId));
+		String requestIdFromMDC = EntityUtils.toString(response.getEntity());
+
+		//Then
+		assertThat(requestIdFromMDC).isEqualTo(requestId);
+	}
+
+	private String dummyEndpointUrl() {
+		return baseConnectorUrl() + "/api/v1/dummy";
+	}
+
+	private String baseConnectorUrl() {
+		return "http://localhost:" + localConnectorPort;
+	}
+}

--- a/src/test/java/com/appdirect/sdk/feature/sample_connector/minimal/MinimalConnector.java
+++ b/src/test/java/com/appdirect/sdk/feature/sample_connector/minimal/MinimalConnector.java
@@ -25,6 +25,7 @@ import com.appdirect.sdk.appmarket.Credentials;
 import com.appdirect.sdk.appmarket.DeveloperSpecificAppmarketCredentialsSupplier;
 import com.appdirect.sdk.appmarket.events.SubscriptionCancel;
 import com.appdirect.sdk.appmarket.events.SubscriptionOrder;
+import com.appdirect.sdk.support.DummyRestController;
 
 /**
  * Sample connector that only supports the mandatory events, not the
@@ -46,5 +47,10 @@ public class MinimalConnector {
 	@Bean
 	public AppmarketEventHandler<SubscriptionCancel> subscriptionCancelHandler() {
 		return event -> success("Mandatory SUB_CANCEL has been processed");
+	}
+
+	@Bean
+	public DummyRestController dummyRestController() {
+		return new DummyRestController();
 	}
 }

--- a/src/test/java/com/appdirect/sdk/support/DummyRestController.java
+++ b/src/test/java/com/appdirect/sdk/support/DummyRestController.java
@@ -1,0 +1,18 @@
+package com.appdirect.sdk.support;
+
+import static com.appdirect.sdk.web.oauth.RequestIdFilter.MDC_REQUEST_ID_KEY;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.web.bind.annotation.RequestMethod.GET;
+
+import org.jboss.logging.MDC;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class DummyRestController {
+
+	@RequestMapping(method = GET, value = "/api/v1/dummy", produces = APPLICATION_JSON_VALUE)
+	public String returnMDC() {
+		return String.valueOf(MDC.get(MDC_REQUEST_ID_KEY));
+	}
+}


### PR DESCRIPTION
Add the content of x-request-id HTTP header (if any) in MDC for all incoming requests. The used key in MDC is requestId.

JIRA ticket (https://appdirect.jira.com/browse/PI-9266):
