### PR TITLE
Adding a NoArgumentConstructor to make these classes easier to deseri…

### DIFF
--- a/src/main/java/com/appdirect/sdk/appmarket/events/AddonSubscriptionCancel.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/events/AddonSubscriptionCancel.java
@@ -16,16 +16,18 @@ package com.appdirect.sdk.appmarket.events;
 import java.util.Map;
 
 import lombok.EqualsAndHashCode;
-import lombok.Value;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 /**
  * A developer-facing event representing cancellation of an addon account requested by the AppMarket
  */
-@Value
+@Getter
 @EqualsAndHashCode(callSuper = true)
+@NoArgsConstructor
 public class AddonSubscriptionCancel extends EventWithContext {
-	private final String accountIdentifier;
-	private final String parentAccountIdentifier;
+	private String accountIdentifier;
+	private String parentAccountIdentifier;
 
 	public AddonSubscriptionCancel(String accountIdentifier,
 								   String parentAccountIdentifier,

--- a/src/main/java/com/appdirect/sdk/appmarket/events/AddonSubscriptionOrder.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/events/AddonSubscriptionOrder.java
@@ -15,20 +15,24 @@ package com.appdirect.sdk.appmarket.events;
 
 import java.util.Map;
 
+import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 /**
  * Developer-facing event representing a SUBSCRIPTION_ORDER made for an add-on to the main product.
  */
 @Getter
 @EqualsAndHashCode(callSuper = true)
+@AllArgsConstructor
+@NoArgsConstructor
 public class AddonSubscriptionOrder extends EventWithContext {
-	private final UserInfo purchaserInfo;
-	private final CompanyInfo companyInfo;
-	private final OrderInfo orderInfo;
-	private final String partner;
-	private final String parentAccountIdentifier;
+	private UserInfo purchaserInfo;
+	private CompanyInfo companyInfo;
+	private OrderInfo orderInfo;
+	private String partner;
+	private String parentAccountIdentifier;
 
 	public AddonSubscriptionOrder(String consumerKeyUsedByTheRequest,
 								  EventFlag flag,

--- a/src/main/java/com/appdirect/sdk/appmarket/events/EventWithContext.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/events/EventWithContext.java
@@ -19,9 +19,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.NoArgsConstructor;
 
 /**
  * abstract event type that offers the consumer key used by the request publishing the event,
@@ -29,18 +30,19 @@ import lombok.RequiredArgsConstructor;
  */
 @Getter
 @EqualsAndHashCode
-@RequiredArgsConstructor
+@AllArgsConstructor
+@NoArgsConstructor
 public abstract class EventWithContext {
 	/**
 	 * Returns the consumer key that was used by the appmarket to publish this event.
 	 * You can use this to determine which product is the originator of this event.
 	 */
-	private final String consumerKeyUsedByTheRequest;
-	private final Map<String, String[]> queryParameters;
+	private String consumerKeyUsedByTheRequest;
+	private Map<String, String[]> queryParameters;
 	@Getter(AccessLevel.NONE)
-	private final EventFlag flag;
-	private final String eventToken;
-	private final String marketplaceUrl;
+	private EventFlag flag;
+	private String eventToken;
+	private String marketplaceUrl;
 
 	/**
 	 * Returns the query parameters that were passed to the endpoint when this event was received.

--- a/src/main/java/com/appdirect/sdk/appmarket/events/SubscriptionCancel.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/events/SubscriptionCancel.java
@@ -16,15 +16,17 @@ package com.appdirect.sdk.appmarket.events;
 import java.util.Map;
 
 import lombok.EqualsAndHashCode;
-import lombok.Value;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 /**
  * A developer-facing event representing cancellation of an account requested by the AppMarket
  */
-@Value
+@Getter
 @EqualsAndHashCode(callSuper = true)
+@NoArgsConstructor
 public class SubscriptionCancel extends EventWithContext {
-	private final String accountIdentifier;
+	private String accountIdentifier;
 
 	public SubscriptionCancel(String consumerKeyUsedByTheRequest,
 							  String accountIdentifier,

--- a/src/main/java/com/appdirect/sdk/appmarket/events/SubscriptionChange.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/events/SubscriptionChange.java
@@ -16,17 +16,19 @@ package com.appdirect.sdk.appmarket.events;
 import java.util.Map;
 
 import lombok.EqualsAndHashCode;
-import lombok.Value;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 /**
  * Developer-facing event representing updates to an account requested by the AppMarket
  */
-@Value
+@Getter
 @EqualsAndHashCode(callSuper = true)
+@NoArgsConstructor
 public class SubscriptionChange extends EventWithContext {
-	private final UserInfo owner;
-	private final OrderInfo order;
-	private final AccountInfo account;
+	private UserInfo owner;
+	private OrderInfo order;
+	private AccountInfo account;
 
 	public SubscriptionChange(String consumerKeyUsedByTheRequest,
 							  UserInfo owner,

--- a/src/main/java/com/appdirect/sdk/appmarket/events/SubscriptionClosed.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/events/SubscriptionClosed.java
@@ -16,6 +16,8 @@ package com.appdirect.sdk.appmarket.events;
 import java.util.Map;
 
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 /**
  * Represents one of the subtypes of the Subscription Notice event sent by the App Market.
@@ -29,8 +31,10 @@ import lombok.EqualsAndHashCode;
  * @see <a href="https://docs.appdirect.com/developer/distribution/event-notifications/subscription-events#notice-types">SUBSCRIPTION_NOTICE types</a>
  */
 @EqualsAndHashCode(callSuper = true)
+@Getter
+@NoArgsConstructor
 public class SubscriptionClosed extends EventWithContext {
-	private final AccountInfo accountInfo;
+	private AccountInfo accountInfo;
 
 	public SubscriptionClosed(String consumerKeyUsedByTheRequest,
 							  AccountInfo accountInfo,
@@ -41,9 +45,5 @@ public class SubscriptionClosed extends EventWithContext {
 
 		super(consumerKeyUsedByTheRequest, queryParameters, flag, eventToken, marketplaceUrl);
 		this.accountInfo = accountInfo;
-	}
-
-	public AccountInfo getAccountInfo() {
-		return accountInfo;
 	}
 }

--- a/src/main/java/com/appdirect/sdk/appmarket/events/SubscriptionDeactivated.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/events/SubscriptionDeactivated.java
@@ -16,6 +16,8 @@ package com.appdirect.sdk.appmarket.events;
 import java.util.Map;
 
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 /**
  * Represents one of the subtypes of the Subscription Notice event sent by the App Market.
@@ -27,8 +29,10 @@ import lombok.EqualsAndHashCode;
  * @see <a href="https://docs.appdirect.com/developer/distribution/event-notifications/subscription-events#notice-types">SUBSCRIPTION_NOTICE types</a>
  */
 @EqualsAndHashCode(callSuper = true)
+@Getter
+@NoArgsConstructor
 public class SubscriptionDeactivated extends EventWithContext {
-	private final AccountInfo accountInfo;
+	private AccountInfo accountInfo;
 
 	public SubscriptionDeactivated(String consumerKeyUsedByTheRequest,
 								   AccountInfo accountInfo,
@@ -39,9 +43,5 @@ public class SubscriptionDeactivated extends EventWithContext {
 
 		super(consumerKeyUsedByTheRequest, queryParameters, flag, eventToken, marketplaceUrl);
 		this.accountInfo = accountInfo;
-	}
-
-	public AccountInfo getAccountInfo() {
-		return accountInfo;
 	}
 }

--- a/src/main/java/com/appdirect/sdk/appmarket/events/SubscriptionOrder.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/events/SubscriptionOrder.java
@@ -19,19 +19,21 @@ import java.util.Optional;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 /**
  * Developer-facing event creation of an account requested by the AppMarket
  */
 @Getter
 @EqualsAndHashCode(callSuper = true)
+@NoArgsConstructor
 public class SubscriptionOrder extends EventWithContext {
-	private final UserInfo purchaserInfo;
-	private final Map<String, String> configuration;
-	private final CompanyInfo companyInfo;
-	private final OrderInfo orderInfo;
-	private final String partner;
-	private final String applicationUuid;
+	private UserInfo purchaserInfo;
+	private Map<String, String> configuration;
+	private CompanyInfo companyInfo;
+	private OrderInfo orderInfo;
+	private String partner;
+	private String applicationUuid;
 
 	public SubscriptionOrder(String consumerKeyUsedByTheRequest,
 							 EventFlag flag,

--- a/src/main/java/com/appdirect/sdk/appmarket/events/SubscriptionReactivated.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/events/SubscriptionReactivated.java
@@ -16,6 +16,8 @@ package com.appdirect.sdk.appmarket.events;
 import java.util.Map;
 
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 /**
  * Represents one of the subtypes of the Subscription Notice event sent by the App Market.
@@ -24,8 +26,10 @@ import lombok.EqualsAndHashCode;
  * @see <a href="https://docs.appdirect.com/developer/distribution/event-notifications/subscription-events#notice-types">SUBSCRIPTION_NOTICE types</a>
  */
 @EqualsAndHashCode(callSuper = true)
+@Getter
+@NoArgsConstructor
 public class SubscriptionReactivated extends EventWithContext {
-	private final AccountInfo accountInfo;
+	private AccountInfo accountInfo;
 
 	public SubscriptionReactivated(String consumerKeyUsedByTheRequest,
 								   AccountInfo accountInfo,
@@ -35,9 +39,5 @@ public class SubscriptionReactivated extends EventWithContext {
 								   String marketplaceUrl) {
 		super(consumerKeyUsedByTheRequest, queryParameters, flag, eventToken, marketplaceUrl);
 		this.accountInfo = accountInfo;
-	}
-
-	public AccountInfo getAccountInfo() {
-		return accountInfo;
 	}
 }

--- a/src/main/java/com/appdirect/sdk/appmarket/events/SubscriptionUpcomingInvoice.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/events/SubscriptionUpcomingInvoice.java
@@ -16,6 +16,8 @@ package com.appdirect.sdk.appmarket.events;
 import java.util.Map;
 
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 /**
  * Represents one of the subtypes of the Subscription Notice event sent by the App Market.
@@ -24,8 +26,10 @@ import lombok.EqualsAndHashCode;
  * @see <a href="https://docs.appdirect.com/developer/distribution/event-notifications/subscription-events#notice-types">SUBSCRIPTION_NOTICE types</a>
  */
 @EqualsAndHashCode(callSuper = true)
+@Getter
+@NoArgsConstructor
 public class SubscriptionUpcomingInvoice extends EventWithContext {
-	private final AccountInfo accountInfo;
+	private AccountInfo accountInfo;
 
 	public SubscriptionUpcomingInvoice(String consumerKeyUsedByTheRequest,
 									   AccountInfo accountInfo,
@@ -36,9 +40,5 @@ public class SubscriptionUpcomingInvoice extends EventWithContext {
 
 		super(consumerKeyUsedByTheRequest, queryParameters, flag, eventToken, marketplaceUrl);
 		this.accountInfo = accountInfo;
-	}
-
-	public AccountInfo getAccountInfo() {
-		return accountInfo;
 	}
 }


### PR DESCRIPTION
…alize. Since Jackson and other libraries use reflection for deserialization having a no args constructor aids that process.

JIRA ticket: https://appdirect.jira.com/browse/PI-9543

- [ ] Approved by a PI tech lead
