### PR TITLE
Assuming links is optional, ensuring that getLinks() returns an empty list

### DIFF
--- a/src/main/java/com/appdirect/sdk/appmarket/events/EventInfo.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/events/EventInfo.java
@@ -15,6 +15,7 @@ package com.appdirect.sdk.appmarket.events;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -41,5 +42,11 @@ class EventInfo {
 	private EventPayload payload;
 	private String returnUrl;
 	@Setter private String id;
-	@Builder.Default private List<Link> links = new ArrayList<>();
+	@Builder.Default
+//	@JsonProperty(required = true) 
+	private List<Link> links = new ArrayList<>();
+	
+	public List<Link> getLinks() {
+		return Optional.ofNullable(links).orElseGet(ArrayList::new);
+	}
 }

--- a/src/main/java/com/appdirect/sdk/appmarket/events/EventInfo.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/events/EventInfo.java
@@ -41,11 +41,11 @@ class EventInfo {
 	private UserInfo creator;
 	private EventPayload payload;
 	private String returnUrl;
-	@Setter private String id;
+	@Setter
+	private String id;
 	@Builder.Default
-//	@JsonProperty(required = true) 
 	private List<Link> links = new ArrayList<>();
-	
+
 	public List<Link> getLinks() {
 		return Optional.ofNullable(links).orElseGet(ArrayList::new);
 	}

--- a/src/test/resources/events/subscription-order-without-links.json
+++ b/src/test/resources/events/subscription-order-without-links.json
@@ -1,0 +1,42 @@
+{
+  "type": "SUBSCRIPTION_ORDER",
+  "marketplace": {
+    "partner": "gabrielspub-test",
+    "baseUrl": "{{fake-appmarket-url}}"
+  },
+  "applicationUuid": null,
+  "creator": {
+    "uuid": "dac5f67b-7da7-4603-bb1b-3fd507509081",
+    "openId": "https://gabrielspub-test.byappdirect.com/openid/id/dac5f67b-7da7-4603-bb1b-3fd507509081",
+    "email": "gabriel.x@gmail.com",
+    "firstName": "Gabriel",
+    "lastName": "SomeLastName",
+    "language": "en",
+    "address": null,
+    "attributes": null
+  },
+  "payload": {
+    "user": null,
+    "company": {
+      "uuid": "6c9832df-a5f2-40dc-9fe6-823ac2c4f143",
+      "externalId": null,
+      "name": "Gabriel's Company",
+      "email": null,
+      "phoneNumber": null,
+      "website": null,
+      "country": "US"
+    },
+    "account": null,
+    "addonInstance": null,
+    "addonBinding": null,
+    "order": {
+      "editionCode": "BASIC",
+      "addonOfferingCode": null,
+      "pricingDuration": "MONTHLY",
+      "items": []
+    },
+    "notice": null,
+    "configuration": {}
+  },
+  "returnUrl": null
+}


### PR DESCRIPTION
Fixing: https://github.com/AppDirect/service-integration-sdk/issues/120
We ensure that the getter for the `links` field in `EventInfo` returns an empty list when the value of the field is null.