### PR TITLE
Adding add domain endpoint to be able to add more than one domain to an account

### DIFF
--- a/src/main/java/com/appdirect/sdk/appmarket/domain/DomainAdditionHandler.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/domain/DomainAdditionHandler.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 AppDirect, Inc. and/or its affiliates
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.appdirect.sdk.appmarket.domain;
+
+/**
+ * SDK clients must implement this interface in their {@link org.springframework.context.ApplicationContext}
+ * if they are using the {@link DomainDnsOwnershipVerificationConfiguration}.
+ * The implementation is responsible to add the domain to the account.
+ */
+@FunctionalInterface
+public interface DomainAdditionHandler {
+	void addDomain(String customerId, String domain);
+}

--- a/src/main/java/com/appdirect/sdk/appmarket/domain/DomainAdditionPayload.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/domain/DomainAdditionPayload.java
@@ -1,0 +1,15 @@
+package com.appdirect.sdk.appmarket.domain;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@AllArgsConstructor
+@EqualsAndHashCode
+@Builder
+@Getter
+public class DomainAdditionPayload {
+	private String domainName;
+}

--- a/src/main/java/com/appdirect/sdk/appmarket/domain/DomainDnsOwnershipVerificationConfiguration.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/domain/DomainDnsOwnershipVerificationConfiguration.java
@@ -37,10 +37,14 @@ public abstract class DomainDnsOwnershipVerificationConfiguration {
 	public abstract DomainOwnershipVerificationHandler domainOwnershipVerificationHandler(DomainVerificationNotificationClient domainVerificationNotificationClient);
 
 	@Bean
+	public abstract DomainAdditionHandler domainAdditionHandler();
+
+	@Bean
 	public DomainOwnershipController domainDnsVerificationInfoController(DomainDnsVerificationInfoHandler domainDnsVerificationInfoHandler,
 																		 DomainOwnershipVerificationHandler domainOwnershipVerificationHandler,
+																		 DomainAdditionHandler domainAdditionHandler,
 																		 OAuthKeyExtractor keyExtractor) {
-		return new DomainOwnershipController(domainDnsVerificationInfoHandler, domainOwnershipVerificationHandler, keyExtractor);
+		return new DomainOwnershipController(domainDnsVerificationInfoHandler, domainOwnershipVerificationHandler, domainAdditionHandler, keyExtractor);
 	}
 
 	@Bean

--- a/src/main/java/com/appdirect/sdk/appmarket/domain/DomainOwnershipController.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/domain/DomainOwnershipController.java
@@ -14,6 +14,7 @@
 package com.appdirect.sdk.appmarket.domain;
 
 import static org.springframework.http.HttpStatus.ACCEPTED;
+import static org.springframework.http.HttpStatus.OK;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
 import static org.springframework.web.bind.annotation.RequestMethod.POST;
@@ -21,6 +22,7 @@ import static org.springframework.web.bind.annotation.RequestMethod.POST;
 import javax.servlet.http.HttpServletRequest;
 
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -34,12 +36,16 @@ public class DomainOwnershipController {
 
 	private final DomainDnsVerificationInfoHandler domainDnsVerificationInfoHandler;
 	private final DomainOwnershipVerificationHandler domainOwnershipVerificationHandler;
+	private final DomainAdditionHandler domainAdditionHandler;
 	private final OAuthKeyExtractor keyExtractor;
 
 	DomainOwnershipController(DomainDnsVerificationInfoHandler domainDnsVerificationInfoHandler,
-							  DomainOwnershipVerificationHandler domainOwnershipVerificationHandler, OAuthKeyExtractor keyExtractor) {
+							  DomainOwnershipVerificationHandler domainOwnershipVerificationHandler,
+							  DomainAdditionHandler domainAdditionHandler,
+							  OAuthKeyExtractor keyExtractor) {
 		this.domainDnsVerificationInfoHandler = domainDnsVerificationInfoHandler;
 		this.domainOwnershipVerificationHandler = domainOwnershipVerificationHandler;
+		this.domainAdditionHandler = domainAdditionHandler;
 		this.keyExtractor = keyExtractor;
 	}
 
@@ -68,4 +74,14 @@ public class DomainOwnershipController {
 		domainOwnershipVerificationHandler.verifyDomainOwnership(customerId, domain, callbackUrl, key);
 	}
 
+	@RequestMapping(
+			method = POST,
+			value = "/customers/{customerIdentifier}/domains"
+	)
+	@ResponseStatus(value = OK)
+	public void addDomain(@PathVariable("customerIdentifier") String customerId,
+						  @RequestBody DomainAdditionPayload domainAdditionPayload) {
+
+		domainAdditionHandler.addDomain(customerId, domainAdditionPayload.getDomainName());
+	}
 }

--- a/src/test/java/com/appdirect/sdk/appmarket/domain/DomainOwnershipControllerTest.java
+++ b/src/test/java/com/appdirect/sdk/appmarket/domain/DomainOwnershipControllerTest.java
@@ -34,13 +34,15 @@ public class DomainOwnershipControllerTest {
 	@Mock
 	private DomainOwnershipVerificationHandler domainOwnershipVerificationHandler;
 	@Mock
+	private DomainAdditionHandler domainAdditionHandler;
+	@Mock
 	private OAuthKeyExtractor keyExtractor;
 
 	private DomainOwnershipController tested;
 
 	@Before
 	public void setUp() throws Exception {
-		tested = new DomainOwnershipController(mockDnsVerificationInfoHandler, domainOwnershipVerificationHandler, keyExtractor);
+		tested = new DomainOwnershipController(mockDnsVerificationInfoHandler, domainOwnershipVerificationHandler, domainAdditionHandler, keyExtractor);
 	}
 
 	@Test
@@ -71,5 +73,19 @@ public class DomainOwnershipControllerTest {
 
 		//Then
 		verify(domainOwnershipVerificationHandler).verifyDomainOwnership(testCustomerId, testDomain, callbackUrl, key);
+	}
+
+	@Test
+	public void testAddDomain_whenCalled_thenControllerForwardsToTheUnderlyingHandler() throws Exception {
+		//Given
+		String testCustomerId = "testCustomerId";
+		String testDomain = "example.com";
+		DomainAdditionPayload domainAdditionPayload = new DomainAdditionPayload(testDomain);
+
+		//When
+		tested.addDomain(testCustomerId, domainAdditionPayload);
+
+		//Then
+		verify(domainAdditionHandler).addDomain(testCustomerId, testDomain);
 	}
 }

--- a/src/test/java/com/appdirect/sdk/feature/sample_connector/full/configuration/FullConnectorDomainDnsOwnershipVerificationConfiguration.java
+++ b/src/test/java/com/appdirect/sdk/feature/sample_connector/full/configuration/FullConnectorDomainDnsOwnershipVerificationConfiguration.java
@@ -6,6 +6,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import com.appdirect.sdk.appmarket.domain.DnsOwnershipVerificationRecords;
+import com.appdirect.sdk.appmarket.domain.DomainAdditionHandler;
 import com.appdirect.sdk.appmarket.domain.DomainDnsOwnershipVerificationConfiguration;
 import com.appdirect.sdk.appmarket.domain.DomainDnsVerificationInfoHandler;
 import com.appdirect.sdk.appmarket.domain.DomainOwnershipVerificationHandler;
@@ -18,6 +19,11 @@ public class FullConnectorDomainDnsOwnershipVerificationConfiguration extends Do
 	@Override
 	public DomainOwnershipVerificationHandler domainOwnershipVerificationHandler(DomainVerificationNotificationClient domainVerificationNotificationClient) {
 		return (customerId, domain, callbackUrl, key) -> domainVerificationNotificationClient.resolveDomainVerification(callbackUrl, key, true);
+	}
+
+	@Override
+	public DomainAdditionHandler domainAdditionHandler() {
+		return (customerId, domain) -> {};
 	}
 
 	@Override


### PR DESCRIPTION
It should be possible to link a domain to an account.

We should have the following endpoint:
* `POST /api/v1/domainassociation/customers/{customerIdentifier}/domains`
The **Content-Type** header should be set to **application/json** and the Body should look like:
```
{
    "domainName": "example.com"
}
```
No payload is expected as a response. AppMarket will use the HTTP code to determine if the operation was successful or not. The expected HTTP code for a success is `200`.

resolves #133 
