### PR TITLE
Adding remove domain endpoint to be able to remove a domain from an account

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>3.6.1</version>
+      <version>3.7.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/com/appdirect/sdk/appmarket/domain/DomainDnsOwnershipVerificationConfiguration.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/domain/DomainDnsOwnershipVerificationConfiguration.java
@@ -40,11 +40,20 @@ public abstract class DomainDnsOwnershipVerificationConfiguration {
 	public abstract DomainAdditionHandler domainAdditionHandler();
 
 	@Bean
+	public abstract DomainRemovalHandler domainRemovalHandler();
+
+	@Bean
 	public DomainOwnershipController domainDnsVerificationInfoController(DomainDnsVerificationInfoHandler domainDnsVerificationInfoHandler,
 																		 DomainOwnershipVerificationHandler domainOwnershipVerificationHandler,
 																		 DomainAdditionHandler domainAdditionHandler,
+																		 DomainRemovalHandler domainRemovalHandler,
 																		 OAuthKeyExtractor keyExtractor) {
-		return new DomainOwnershipController(domainDnsVerificationInfoHandler, domainOwnershipVerificationHandler, domainAdditionHandler, keyExtractor);
+		return new DomainOwnershipController(
+				domainDnsVerificationInfoHandler,
+				domainOwnershipVerificationHandler,
+				domainAdditionHandler,
+				domainRemovalHandler,
+				keyExtractor);
 	}
 
 	@Bean

--- a/src/main/java/com/appdirect/sdk/appmarket/domain/DomainOwnershipController.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/domain/DomainOwnershipController.java
@@ -16,6 +16,7 @@ package com.appdirect.sdk.appmarket.domain;
 import static org.springframework.http.HttpStatus.ACCEPTED;
 import static org.springframework.http.HttpStatus.OK;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.web.bind.annotation.RequestMethod.DELETE;
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
 import static org.springframework.web.bind.annotation.RequestMethod.POST;
 
@@ -37,15 +38,18 @@ public class DomainOwnershipController {
 	private final DomainDnsVerificationInfoHandler domainDnsVerificationInfoHandler;
 	private final DomainOwnershipVerificationHandler domainOwnershipVerificationHandler;
 	private final DomainAdditionHandler domainAdditionHandler;
+	private final DomainRemovalHandler domainRemovalHandler;
 	private final OAuthKeyExtractor keyExtractor;
 
 	DomainOwnershipController(DomainDnsVerificationInfoHandler domainDnsVerificationInfoHandler,
 							  DomainOwnershipVerificationHandler domainOwnershipVerificationHandler,
 							  DomainAdditionHandler domainAdditionHandler,
+							  DomainRemovalHandler domainRemovalHandler,
 							  OAuthKeyExtractor keyExtractor) {
 		this.domainDnsVerificationInfoHandler = domainDnsVerificationInfoHandler;
 		this.domainOwnershipVerificationHandler = domainOwnershipVerificationHandler;
 		this.domainAdditionHandler = domainAdditionHandler;
+		this.domainRemovalHandler = domainRemovalHandler;
 		this.keyExtractor = keyExtractor;
 	}
 
@@ -83,5 +87,16 @@ public class DomainOwnershipController {
 						  @RequestBody DomainAdditionPayload domainAdditionPayload) {
 
 		domainAdditionHandler.addDomain(customerId, domainAdditionPayload.getDomainName());
+	}
+
+	@RequestMapping(
+			method = DELETE,
+			value = "/customers/{customerIdentifier}/domains/{domainName}"
+	)
+	@ResponseStatus(value = OK)
+	public void removeDomain(@PathVariable("customerIdentifier") String customerId,
+						  @PathVariable("domainName") String domainName) {
+
+		domainRemovalHandler.removeDomain(customerId, domainName);
 	}
 }

--- a/src/main/java/com/appdirect/sdk/appmarket/domain/DomainRemovalHandler.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/domain/DomainRemovalHandler.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 AppDirect, Inc. and/or its affiliates
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.appdirect.sdk.appmarket.domain;
+
+/**
+ * SDK clients must implement this interface in their {@link org.springframework.context.ApplicationContext}
+ * if they are using the {@link com.appdirect.sdk.appmarket.domain.DomainDnsOwnershipVerificationConfiguration}.
+ * The implementation is responsible to remove the domain from the account.
+ */
+@FunctionalInterface
+public interface DomainRemovalHandler {
+	void removeDomain(String customerId, String domain);
+}

--- a/src/test/java/com/appdirect/sdk/appmarket/domain/DomainOwnershipControllerTest.java
+++ b/src/test/java/com/appdirect/sdk/appmarket/domain/DomainOwnershipControllerTest.java
@@ -36,13 +36,19 @@ public class DomainOwnershipControllerTest {
 	@Mock
 	private DomainAdditionHandler domainAdditionHandler;
 	@Mock
+	private DomainRemovalHandler domainRemovalHandler;
+	@Mock
 	private OAuthKeyExtractor keyExtractor;
 
 	private DomainOwnershipController tested;
 
 	@Before
 	public void setUp() throws Exception {
-		tested = new DomainOwnershipController(mockDnsVerificationInfoHandler, domainOwnershipVerificationHandler, domainAdditionHandler, keyExtractor);
+		tested = new DomainOwnershipController(mockDnsVerificationInfoHandler,
+				domainOwnershipVerificationHandler,
+				domainAdditionHandler,
+				domainRemovalHandler,
+				keyExtractor);
 	}
 
 	@Test
@@ -87,5 +93,18 @@ public class DomainOwnershipControllerTest {
 
 		//Then
 		verify(domainAdditionHandler).addDomain(testCustomerId, testDomain);
+	}
+
+	@Test
+	public void testRemoveDomain_whenCalled_thenControllerForwardsToTheUnderlyingHandler() throws Exception {
+		//Given
+		String testCustomerId = "testCustomerId";
+		String testDomain = "example.com";
+
+		//When
+		tested.removeDomain(testCustomerId, testDomain);
+
+		//Then
+		verify(domainRemovalHandler).removeDomain(testCustomerId, testDomain);
 	}
 }

--- a/src/test/java/com/appdirect/sdk/feature/sample_connector/full/configuration/FullConnectorDomainDnsOwnershipVerificationConfiguration.java
+++ b/src/test/java/com/appdirect/sdk/feature/sample_connector/full/configuration/FullConnectorDomainDnsOwnershipVerificationConfiguration.java
@@ -10,6 +10,7 @@ import com.appdirect.sdk.appmarket.domain.DomainAdditionHandler;
 import com.appdirect.sdk.appmarket.domain.DomainDnsOwnershipVerificationConfiguration;
 import com.appdirect.sdk.appmarket.domain.DomainDnsVerificationInfoHandler;
 import com.appdirect.sdk.appmarket.domain.DomainOwnershipVerificationHandler;
+import com.appdirect.sdk.appmarket.domain.DomainRemovalHandler;
 import com.appdirect.sdk.appmarket.domain.DomainVerificationNotificationClient;
 import com.appdirect.sdk.appmarket.domain.MxDnsRecord;
 import com.appdirect.sdk.appmarket.domain.TxtDnsRecord;
@@ -23,6 +24,11 @@ public class FullConnectorDomainDnsOwnershipVerificationConfiguration extends Do
 
 	@Override
 	public DomainAdditionHandler domainAdditionHandler() {
+		return (customerId, domain) -> {};
+	}
+
+	@Override
+	public DomainRemovalHandler domainRemovalHandler() {
 		return (customerId, domain) -> {};
 	}
 


### PR DESCRIPTION
It should be possible to remove a domain to an account.

We should have the following endpoint:
* `DELETE /api/v1/domainassociation/customers/{customerIdentifier}/domains/{domainName}`

No payload is expected as a response. AppMarket will use the HTTP code to determine if the operation was successful or not. The expected HTTP code for a success is `200`.

resolves #135