### PR TITLE
Renamed resttemplatefactory beans across all configs

### DIFF
--- a/src/main/java/com/appdirect/sdk/appmarket/domain/DomainDnsOwnershipVerificationConfiguration.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/domain/DomainDnsOwnershipVerificationConfiguration.java
@@ -58,11 +58,11 @@ public abstract class DomainDnsOwnershipVerificationConfiguration {
 
 	@Bean
 	public DomainVerificationNotificationClient domainVerificationNotificationClient(DeveloperSpecificAppmarketCredentialsSupplier credentialsSupplier) {
-		return new DomainVerificationNotificationClient(restTemplateFactory(), credentialsSupplier);
+		return new DomainVerificationNotificationClient(domainRestTemplateFactory(), credentialsSupplier);
 	}
 
 	@Bean
-	public RestTemplateFactory restTemplateFactory() {
+	public RestTemplateFactory domainRestTemplateFactory() {
 		return new DefaultRestTemplateFactoryImpl(new AppmarketEventClientExceptionHandler());
 	}
 }

--- a/src/main/java/com/appdirect/sdk/appmarket/events/AppmarketCommunicationConfiguration.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/events/AppmarketCommunicationConfiguration.java
@@ -41,7 +41,7 @@ public class AppmarketCommunicationConfiguration {
 	@Bean
 	public AppmarketEventClient appmarketEventFetcher(DeveloperSpecificAppmarketCredentialsSupplier credentialsSupplier,
 																										@Qualifier("sdkInternalJsonMapper") ObjectMapper mapper) {
-		return new AppmarketEventClient(restTemplateFactory(), credentialsSupplier, mapper);
+		return new AppmarketEventClient(appMarketRestTemplateFactory(), credentialsSupplier, mapper);
 	}
 
 	@Bean
@@ -67,7 +67,7 @@ public class AppmarketCommunicationConfiguration {
 	}
 
 	@Bean
-	public RestTemplateFactory restTemplateFactory() {
+	public RestTemplateFactory appMarketRestTemplateFactory() {
 		return new DefaultRestTemplateFactoryImpl(new AppmarketEventClientExceptionHandler());
 	}
 

--- a/src/main/java/com/appdirect/sdk/appmarket/usersync/UserSyncConfiguration.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/usersync/UserSyncConfiguration.java
@@ -30,12 +30,12 @@ public class UserSyncConfiguration {
 	}
 
 	@Bean
-	public RestTemplateFactory restTemplateFactory() {
+	public RestTemplateFactory userSyncRestTemplateFactory() {
 		return new UserSyncRestTemplateFactoryImpl();
 	}
 
 	@Bean
 	public UserSyncApiClient userSyncApiClient() {
-		return new UserSyncApiClient(restTemplateFactory());
+		return new UserSyncApiClient(userSyncRestTemplateFactory());
 	}
 }


### PR DESCRIPTION
JIRA ticket: https://appdirect.jira.com/browse/PI-11756

RestTemplateFactory beans were named same across different java configs, which resultsrest templates being injected into wrong places.

- [x] Approved by a PI tech lead

@hooriak