### PR TITLE
Adding subscription migration endpoint

### DIFF
--- a/src/main/java/com/appdirect/sdk/appmarket/events/AppmarketCommunicationConfiguration.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/events/AppmarketCommunicationConfiguration.java
@@ -21,6 +21,7 @@ import com.appdirect.sdk.appmarket.DeveloperSpecificAppmarketCredentialsSupplier
 import com.appdirect.sdk.appmarket.migration.AppmarketMigrationController;
 import com.appdirect.sdk.appmarket.migration.AppmarketMigrationService;
 import com.appdirect.sdk.appmarket.migration.CustomerAccountValidationHandler;
+import com.appdirect.sdk.appmarket.migration.SubscriptionMigrationHandler;
 import com.appdirect.sdk.appmarket.migration.SubscriptionValidationHandler;
 import com.appdirect.sdk.web.exception.AppmarketEventClientExceptionHandler;
 import com.appdirect.sdk.web.oauth.DefaultRestTemplateFactoryImpl;
@@ -57,8 +58,8 @@ public class AppmarketCommunicationConfiguration {
 	}
 
 	@Bean
-	public AppmarketMigrationService appmarketMigrationService(CustomerAccountValidationHandler customerAccountValidationHandler, SubscriptionValidationHandler subscriptionValidationHandler) {
-		return new AppmarketMigrationService(customerAccountValidationHandler, subscriptionValidationHandler);
+	public AppmarketMigrationService appmarketMigrationService(CustomerAccountValidationHandler customerAccountValidationHandler, SubscriptionValidationHandler subscriptionValidationHandler, SubscriptionMigrationHandler subscriptionMigrationHandler) {
+		return new AppmarketMigrationService(customerAccountValidationHandler, subscriptionValidationHandler, subscriptionMigrationHandler);
 	}
 
 	@Bean

--- a/src/main/java/com/appdirect/sdk/appmarket/migration/AppmarketMigrationController.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/migration/AppmarketMigrationController.java
@@ -64,4 +64,15 @@ public class AppmarketMigrationController {
 	public Callable<APIResult> validateISVSubscription(@RequestBody Map<String, String> isvSubscriptionData) {
 		return () -> migrationService.validateSubscription(isvSubscriptionData);
 	}
+
+	/**
+	 * Migrate a subscription which is already validated by {@link AppmarketMigrationController#validateISVSubscription(Map)}
+	 *
+	 * @param subscription the subscription record to be migrated
+	 * @return an {@link APIResult#success(String)} in case the migration is successful and a {@link APIResult#failure(ErrorCode, String)}
+	 */
+	@RequestMapping(method = POST, value = "/api/v1/migration/subscription", produces = APPLICATION_JSON_VALUE, consumes = APPLICATION_JSON_VALUE)
+	public Callable<APIResult> migrate(@RequestBody Subscription subscription) {
+		return () -> migrationService.migrate(subscription);
+	}
 }

--- a/src/main/java/com/appdirect/sdk/appmarket/migration/AppmarketMigrationService.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/migration/AppmarketMigrationService.java
@@ -28,6 +28,7 @@ import com.appdirect.sdk.appmarket.events.APIResult;
 public class AppmarketMigrationService {
 	private final CustomerAccountValidationHandler customerAccountValidationHandler;
 	private final SubscriptionValidationHandler subscriptionValidationHandler;
+	private final SubscriptionMigrationHandler subscriptionMigrationHandler;
 
 	public APIResult validateCustomerAccount(Map<String, String> customerAccountData) {
 		return customerAccountValidationHandler.validate(customerAccountData);
@@ -35,5 +36,9 @@ public class AppmarketMigrationService {
 
 	public APIResult validateSubscription(Map<String, String> subscriptionData) {
 		return subscriptionValidationHandler.validate(subscriptionData);
+	}
+
+	public APIResult migrate(Subscription subscription) {
+		return subscriptionMigrationHandler.handle(subscription);
 	}
 }

--- a/src/main/java/com/appdirect/sdk/appmarket/migration/DefaultMigrationHandlers.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/migration/DefaultMigrationHandlers.java
@@ -28,4 +28,9 @@ public class DefaultMigrationHandlers {
 	public SubscriptionValidationHandler subscriptionValidatorHandler() {
 		return subscriptionData -> APIResult.failure(ErrorCode.CONFIGURATION_ERROR, "Subscription validation is not supported.");
 	}
+
+	@Bean
+	public SubscriptionMigrationHandler subscriptionMigrationHandler() {
+		return subscription -> APIResult.failure(ErrorCode.CONFIGURATION_ERROR, "Subscription migration is not supported.");
+	}
 }

--- a/src/main/java/com/appdirect/sdk/appmarket/migration/Subscription.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/migration/Subscription.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018 AppDirect, Inc. and/or its affiliates
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.appdirect.sdk.appmarket.migration;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Subscription {
+	private String partner;
+	private String tenantIdentifier;
+	private String subscriptionIdentifier;
+	private String applicationIdentifier;
+	private String edition;
+	private List<OrderUnit> orderUnits;
+
+	@Getter
+	@Setter
+	@ToString
+	@EqualsAndHashCode
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	class OrderUnit {
+		private String unitType;
+		private BigDecimal unit;
+	}
+}

--- a/src/main/java/com/appdirect/sdk/appmarket/migration/SubscriptionMigrationHandler.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/migration/SubscriptionMigrationHandler.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2018 AppDirect, Inc. and/or its affiliates
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.appdirect.sdk.appmarket.migration;
+
+import com.appdirect.sdk.appmarket.events.APIResult;
+
+@FunctionalInterface
+public interface SubscriptionMigrationHandler {
+	APIResult handle(Subscription subscription);
+}

--- a/src/test/java/com/appdirect/sdk/appmarket/migration/AppmarketMigrationControllerTest.java
+++ b/src/test/java/com/appdirect/sdk/appmarket/migration/AppmarketMigrationControllerTest.java
@@ -14,6 +14,7 @@
 package com.appdirect.sdk.appmarket.migration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyMapOf;
 import static org.mockito.Mockito.when;
 
@@ -79,5 +80,25 @@ public class AppmarketMigrationControllerTest {
 
 		assertThat(apiResult.isSuccess()).isFalse();
 		assertThat(apiResult.getMessage()).isEqualTo("Failure in validation");
+	}
+
+	@Test
+	public void migrateISVSubscription_success() throws Exception {
+		when(migrationService.migrate(any(Subscription.class))).thenReturn(APIResult.success("Success"));
+		Callable<APIResult> result = migrationController.migrate(new Subscription());
+		APIResult apiResult = result.call();
+
+		assertThat(apiResult.isSuccess()).isTrue();
+		assertThat(apiResult.getMessage()).isEqualTo("Success");
+	}
+
+	@Test
+	public void migrationISVSubscription_failure() throws Exception {
+		when(migrationService.migrate(any(Subscription.class))).thenReturn(APIResult.failure(ErrorCode.CONFIGURATION_ERROR, "Migration Failed"));
+		Callable<APIResult> result = migrationController.migrate(new Subscription());
+		APIResult apiResult = result.call();
+
+		assertThat(apiResult.isSuccess()).isFalse();
+		assertThat(apiResult.getMessage()).isEqualTo("Migration Failed");
 	}
 }


### PR DESCRIPTION
JIRA ticket: https://appdirect.jira.com/browse/PI-12125

Adding an endpoint for migrating subscriptions from an AppDirect marketplace to connectors. The migration process will follow the same procedure as regular marketplace migrations, but an extension is expected to **validate** (via the validation endpoint) and **dispatch** the subscription payload to the correct connector.

- [x] Approved by a PI tech lead
