### PR TITLE
PI-12313 Adding AccountInfo to SubscriptionOrder.

### DIFF
--- a/src/main/java/com/appdirect/sdk/appmarket/events/SubscriptionOrder.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/events/SubscriptionOrder.java
@@ -31,6 +31,7 @@ public class SubscriptionOrder extends EventWithContext {
 	private UserInfo purchaserInfo;
 	private Map<String, String> configuration;
 	private CompanyInfo companyInfo;
+	private AccountInfo accountInfo;
 	private OrderInfo orderInfo;
 	private String partner;
 	private String applicationUuid;
@@ -41,6 +42,7 @@ public class SubscriptionOrder extends EventWithContext {
 							 UserInfo purchaserInfo,
 							 Map<String, String> configuration,
 							 CompanyInfo companyInfo,
+							 AccountInfo accountInfo,
 							 OrderInfo orderInfo,
 							 String partner,
 							 String applicationUuid,
@@ -53,6 +55,7 @@ public class SubscriptionOrder extends EventWithContext {
 		this.purchaserInfo = purchaserInfo;
 		this.configuration = configuration;
 		this.companyInfo = companyInfo;
+		this.accountInfo = accountInfo;
 		this.orderInfo = orderInfo;
 		this.partner = partner;
 		this.applicationUuid = applicationUuid;

--- a/src/main/java/com/appdirect/sdk/appmarket/events/SubscriptionOrderEventParser.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/events/SubscriptionOrderEventParser.java
@@ -29,6 +29,7 @@ class SubscriptionOrderEventParser implements EventParser<SubscriptionOrder> {
 				eventInfo.getCreator(),
 				eventInfo.getPayload().getConfiguration(),
 				eventInfo.getPayload().getCompany(),
+				eventInfo.getPayload().getAccount(),
 				eventInfo.getPayload().getOrder(),
 				eventInfo.getMarketplace().getPartner(),
 				eventInfo.getApplicationUuid(),

--- a/src/test/java/com/appdirect/sdk/appmarket/events/SubscriptionOrderEventParserTest.java
+++ b/src/test/java/com/appdirect/sdk/appmarket/events/SubscriptionOrderEventParserTest.java
@@ -47,6 +47,15 @@ public class SubscriptionOrderEventParserTest {
 	}
 
 	@Test
+	public void parse_setsTheAccountInfo_fromThePayload() throws Exception {
+		EventInfo rawEventWithAcccountInfo = eventWithAccountInfo("my-account").build();
+
+		SubscriptionOrder parsedEvent = parser.parse(rawEventWithAcccountInfo, defaultEventContext());
+
+		assertThat(parsedEvent.getAccountInfo().getAccountIdentifier()).isEqualTo("my-account");
+	}
+
+	@Test
 	public void parse_setsTheConfiguration_fromThePayload() throws Exception {
 		EventInfo rawEventWithConfig = eventWithConfig(config("one", "apple", "two", "apples")).build();
 
@@ -125,6 +134,10 @@ public class SubscriptionOrderEventParserTest {
 
 	private EventInfoBuilder eventWithCompanyInfo(String companyName) {
 		return someEvent().payload(EventPayload.builder().company(CompanyInfo.builder().name(companyName).build()).build());
+	}
+
+	private EventInfoBuilder eventWithAccountInfo(String uuid) {
+		return someEvent().payload(EventPayload.builder().account(AccountInfo.builder().accountIdentifier(uuid).build()).build());
 	}
 
 	private EventInfoBuilder someEvent() {

--- a/src/test/java/com/appdirect/sdk/appmarket/events/SubscriptionOrderTest.java
+++ b/src/test/java/com/appdirect/sdk/appmarket/events/SubscriptionOrderTest.java
@@ -28,7 +28,7 @@ public class SubscriptionOrderTest {
 				UserInfo.builder().build(),
 				new HashMap<>(),
 				CompanyInfo.builder().build(),
-				OrderInfo.builder().build(),
+				AccountInfo.builder().build(), OrderInfo.builder().build(),
 				"partner",
 				"appUuid",
 				null,


### PR DESCRIPTION
Until now there has not been a connector that requires add-ons. We need to get the parentAccountIdentifier from the AccountInfo in order to process an Add-On purchase in Microsoft

JIRA ticket: [PI-12313](https://appdirect.jira.com/browse/PI-12313)

- [ ] Approved by a PI tech lead
