### PR TITLE
Introduce `openid.secured.url.patterns` property configuration to be able to configure a list of custom pattern that should be secured.

### DIFF
--- a/src/main/java/com/appdirect/sdk/web/oauth/model/OpenIdCustomUrlPattern.java
+++ b/src/main/java/com/appdirect/sdk/web/oauth/model/OpenIdCustomUrlPattern.java
@@ -1,0 +1,13 @@
+package com.appdirect.sdk.web.oauth.model;
+
+import java.util.List;
+
+import lombok.Data;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Data
+@ConfigurationProperties(prefix = "openid.secured.url")
+public class OpenIdCustomUrlPattern {
+	private List<String> patterns;
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,4 +1,8 @@
-openid.identityUrl: http://fake.url
+openid:
+  identityUrl: http://fake.url
+  secured.url.patterns:
+    - /api/v1/dummy/**
+
 authentication:
   roles:
     admin:

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -21,4 +21,6 @@
     <root level="WARN">
         <appender-ref ref="STDOUT"/>
     </root>
+
+    <logger name="com.appdirect.sdk.web.oauth" level="DEBUG" />
 </configuration>


### PR DESCRIPTION
Introduce `openid.secured.url.patterns` property configuration to be able to configure a list of custom pattern that should be secured.

resolves #161
