### PR TITLE
PI-14935

### DIFF
--- a/src/main/java/com/appdirect/sdk/web/oauth/OAuthSignedClientHttpRequestFactory.java
+++ b/src/main/java/com/appdirect/sdk/web/oauth/OAuthSignedClientHttpRequestFactory.java
@@ -44,6 +44,9 @@ public class OAuthSignedClientHttpRequestFactory extends SimpleClientHttpRequest
 	@Override
 	protected void prepareConnection(HttpURLConnection connection, String httpMethod) throws IOException {
 		super.prepareConnection(connection, httpMethod);
+
+		connection.setInstanceFollowRedirects(true);
+
 		try {
 			consumer.sign(connection);
 			log.debug("Signed request to {}", connection.getURL());

--- a/src/test/java/com/appdirect/sdk/web/oauth/OAuthSignedClientHttpRequestFactoryTest.java
+++ b/src/test/java/com/appdirect/sdk/web/oauth/OAuthSignedClientHttpRequestFactoryTest.java
@@ -71,6 +71,15 @@ public class OAuthSignedClientHttpRequestFactoryTest {
 				.hasCauseExactlyInstanceOf(OAuthMessageSignerException.class);
 	}
 
+	@Test
+	public void prepareConnection_acceptsRedirects() throws Exception {
+		HttpURLConnection connection = connectionTo("http://some-domain.com/?p1=v1");
+
+		requestFactory.prepareConnection(connection, "POST");
+
+		verify(connection).setInstanceFollowRedirects(true);
+	}
+
 	private HttpURLConnection connectionTo(String url) throws IOException {
 		HttpURLConnection connection = mock(HttpURLConnection.class);
 		when(connection.getURL()).thenReturn(URI.create(url).toURL());


### PR DESCRIPTION
JIRA ticket: https://appdirect.jira.com/browse/PI-14935

Right now when a Connector implementing the SDK tries to resolve an event using a marketplace base URL that redirects the request to another url (e.g. www.appdirect.com that redirects to marketplace.appdirect.com) the request fails with a 302 http code since following redirections is not enabled for methods other than GET. This leads to events being stuck in pending.

This PRs enables following redirections for other methods.

Event sample:
![image](https://user-images.githubusercontent.com/5589148/52804965-468cb480-3064-11e9-94f3-979ab61c922e.png)

Error log:
![image](https://user-images.githubusercontent.com/5589148/52804942-3b398900-3064-11e9-8b1e-24cdc59d9abb.png)

- [x] Approved by a PI tech lead