### PR TITLE
PI-15372: insert environment variables with the pattern CONNECTOR_ALLOWED_CREDENTIALS_XXX

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,8 @@
 
     <properties>
         <java.version>1.8</java.version>
+        <guava.version>27.1-jre</guava.version>
+        <testng.version>6.14.3</testng.version>
     </properties>
 
     <parent>
@@ -90,6 +92,12 @@
             <groupId>org.springframework.hateoas</groupId>
             <artifactId>spring-hateoas</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
+        </dependency>
         <!-- Testing -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -120,6 +128,14 @@
             <version>2.6.0</version>
             <scope>test</scope>
         </dependency>
+        <!-- TestNG -->
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>${testng.version}</version>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock-standalone</artifactId>

--- a/src/main/java/com/appdirect/sdk/ConnectorSdkConfiguration.java
+++ b/src/main/java/com/appdirect/sdk/ConnectorSdkConfiguration.java
@@ -23,6 +23,7 @@ import com.appdirect.sdk.appmarket.migration.DefaultMigrationHandlers;
 import com.appdirect.sdk.appmarket.restrictions.RestrictionConfiguration;
 import com.appdirect.sdk.appmarket.usersync.UserSyncConfiguration;
 import com.appdirect.sdk.appmarket.validation.DefaultValidationHandlers;
+import com.appdirect.sdk.configuration.OAuthCredentialsConfiguration;
 import com.appdirect.sdk.vendorFields.configuration.VendorFieldConfiguration;
 import com.appdirect.sdk.vendorFields.configuration.VendorRequiredFieldConfiguration;
 import com.appdirect.sdk.web.config.JacksonConfiguration;
@@ -35,18 +36,19 @@ import com.appdirect.sdk.web.oauth.SecurityConfiguration;
  */
 @Configuration
 @Import({
-		MvcConfiguration.class,
-		JacksonConfiguration.class,
-		SecurityConfiguration.class,
-		DefaultEventHandlersForOptionalEvents.class,
-		EventHandlingConfiguration.class,
-		AppmarketCommunicationConfiguration.class,
-		DefaultMigrationHandlers.class,
-		DefaultValidationHandlers.class,
-		UserSyncConfiguration.class,
-		RestrictionConfiguration.class,
-		VendorFieldConfiguration.class,
-		VendorRequiredFieldConfiguration.class
+	MvcConfiguration.class,
+	JacksonConfiguration.class,
+	SecurityConfiguration.class,
+	DefaultEventHandlersForOptionalEvents.class,
+	EventHandlingConfiguration.class,
+	AppmarketCommunicationConfiguration.class,
+	DefaultMigrationHandlers.class,
+	DefaultValidationHandlers.class,
+	UserSyncConfiguration.class,
+	RestrictionConfiguration.class,
+	VendorFieldConfiguration.class,
+	VendorRequiredFieldConfiguration.class,
+	OAuthCredentialsConfiguration.class
 })
 public class ConnectorSdkConfiguration {
 }

--- a/src/main/java/com/appdirect/sdk/configuration/ConnectorOAuthConfigurationProperties.java
+++ b/src/main/java/com/appdirect/sdk/configuration/ConnectorOAuthConfigurationProperties.java
@@ -1,0 +1,22 @@
+package com.appdirect.sdk.configuration;
+
+import java.util.Map;
+import java.util.Optional;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import com.google.common.collect.Maps;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "connector.oauth")
+class ConnectorOAuthConfigurationProperties {
+	@Value("${connector.allowed.credentials:#{null}}")
+	private Optional<String> legacyCredentials; //Kept for backward compatibility
+
+	private Map<String, String> credentials = Maps.newHashMap();
+}

--- a/src/main/java/com/appdirect/sdk/configuration/OAuthCredentialsConfiguration.java
+++ b/src/main/java/com/appdirect/sdk/configuration/OAuthCredentialsConfiguration.java
@@ -1,0 +1,32 @@
+package com.appdirect.sdk.configuration;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.appdirect.sdk.appmarket.DeveloperSpecificAppmarketCredentialsSupplier;
+import com.appdirect.sdk.credentials.StringBackedCredentialsSupplier;
+
+@Configuration
+@EnableConfigurationProperties(ConnectorOAuthConfigurationProperties.class)
+@RequiredArgsConstructor
+public class OAuthCredentialsConfiguration {
+	private static final String DELIMITER = ",";
+
+	private final ConnectorOAuthConfigurationProperties connectorOAuthConfigurationProperties;
+
+	@Bean
+	public DeveloperSpecificAppmarketCredentialsSupplier environmentCredentialsSupplier() {
+		String oAuthCredentials = String.join(DELIMITER, connectorOAuthConfigurationProperties.getCredentials().values());
+
+		//Backward compatibility
+		if (connectorOAuthConfigurationProperties.getLegacyCredentials().isPresent()) {
+			String legacyCredentials = connectorOAuthConfigurationProperties.getLegacyCredentials().get();
+			oAuthCredentials = oAuthCredentials.isEmpty() ?  legacyCredentials : String.join(DELIMITER, oAuthCredentials, legacyCredentials);
+		}
+
+		return new StringBackedCredentialsSupplier(oAuthCredentials);
+	}
+}

--- a/src/test/java/com/appdirect/sdk/configuration/OAuthCredentialsConfigurationTest.java
+++ b/src/test/java/com/appdirect/sdk/configuration/OAuthCredentialsConfigurationTest.java
@@ -1,0 +1,70 @@
+package com.appdirect.sdk.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.testng.collections.Maps;
+
+import com.appdirect.sdk.appmarket.DeveloperSpecificAppmarketCredentialsSupplier;
+
+public class OAuthCredentialsConfigurationTest {
+	private static final String LEGACY_CREDENTIALS = "legacyKey:legacySecret";
+	private static final String CREDENTIALS= "key:secret";
+
+	@Mock
+	private ConnectorOAuthConfigurationProperties properties;
+	private OAuthCredentialsConfiguration oAuthCredentialsConfiguration;
+
+	@BeforeMethod
+	public void setUp() {
+		MockitoAnnotations.initMocks(this);
+		oAuthCredentialsConfiguration = new OAuthCredentialsConfiguration(properties);
+	}
+
+	@Test
+	public void testSupplierCreation_withOnlyLegacyCreds() {
+		when(properties.getLegacyCredentials()).thenReturn(Optional.of(LEGACY_CREDENTIALS));
+		when(properties.getCredentials()).thenReturn(Maps.newHashMap());
+
+		DeveloperSpecificAppmarketCredentialsSupplier supplier = oAuthCredentialsConfiguration.environmentCredentialsSupplier();
+
+		assertThat(supplier).isNotNull();
+		assertThat(supplier.getConsumerCredentials("legacyKey").getDeveloperSecret()).isEqualTo("legacySecret");
+	}
+
+	@Test
+	public void testSupplierCreation_withoutLegacyCreds() {
+		Map<String, String> credentialsMap = Maps.newHashMap();
+		credentialsMap.put("testCredential", CREDENTIALS);
+
+		when(properties.getLegacyCredentials()).thenReturn(Optional.empty());
+		when(properties.getCredentials()).thenReturn(credentialsMap);
+
+		DeveloperSpecificAppmarketCredentialsSupplier supplier = oAuthCredentialsConfiguration.environmentCredentialsSupplier();
+
+		assertThat(supplier).isNotNull();
+		assertThat(supplier.getConsumerCredentials("key").getDeveloperSecret()).isEqualTo("secret");
+	}
+
+	@Test
+	public void testSupplierCreation_withBothCreds() {
+		Map<String, String> credentialsMap = Maps.newHashMap();
+		credentialsMap.put("testCredential", CREDENTIALS);
+
+		when(properties.getLegacyCredentials()).thenReturn(Optional.of(LEGACY_CREDENTIALS));
+		when(properties.getCredentials()).thenReturn(credentialsMap);
+
+		DeveloperSpecificAppmarketCredentialsSupplier supplier = oAuthCredentialsConfiguration.environmentCredentialsSupplier();
+
+		assertThat(supplier).isNotNull();
+		assertThat(supplier.getConsumerCredentials("key").getDeveloperSecret()).isEqualTo("secret");
+		assertThat(supplier.getConsumerCredentials("legacyKey").getDeveloperSecret()).isEqualTo("legacySecret");
+	}
+}


### PR DESCRIPTION
#### [PI-15372](https://appdirect.jira.com/browse/PI-15372)

#### Description
The Google Connector contains a customization that provides the ability to insert environment variables with the pattern "CONNECTOR_ALLOWED_CREDENTIALS_XXX" and insert them directly in the environment, instead of having only one variable with the list of key-values. The idea is to move this new logic to the SDK, in order to reuse it with other connectors

#### Manual merge checklist:
- [ ] Code Review completed
- [ ] Code coverage
- [ ] QA Validation completed
  - Testrail TestCase/Plan link:
- [ ] Approved by a PI tech lead
- [ ] Github checks all green

#### Notification(s)
@AppDirect/connectors 


