### PR TITLE
Added InitBinder for VendorFieldValidationController and added UT for it

### DIFF
--- a/src/main/java/com/appdirect/sdk/vendorFields/controller/VendorFieldValidationController.java
+++ b/src/main/java/com/appdirect/sdk/vendorFields/controller/VendorFieldValidationController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.appdirect.sdk.vendorFields.converter.FlowTypeConverter;
+import com.appdirect.sdk.vendorFields.converter.LocaleConverter;
 import com.appdirect.sdk.vendorFields.converter.OperationTypeConverter;
 import com.appdirect.sdk.vendorFields.handler.VendorFieldValidationHandler;
 import com.appdirect.sdk.vendorFields.model.FlowType;
@@ -44,6 +45,7 @@ public class VendorFieldValidationController {
 	public Callable<VendorFieldsValidationResponse> validateFields(
 			@RequestBody VendorFieldsValidationRequest vendorFieldsValidationRequest,
 			@RequestHeader(value = "Accept-Language") List<Locale> locales) {
+
 		log.info(
 				"Calling validate fields API with editionCode={}, flowType={}, operationType={}, partner={}, applicationIdentifier={}, locales={}",
 				vendorFieldsValidationRequest.getEditionCode(),
@@ -62,5 +64,6 @@ public class VendorFieldValidationController {
 	public void initBinder(final WebDataBinder webdataBinder) {
 		webdataBinder.registerCustomEditor(FlowType.class, new FlowTypeConverter());
 		webdataBinder.registerCustomEditor(OperationType.class, new OperationTypeConverter());
+		webdataBinder.registerCustomEditor(List.class, new LocaleConverter());
 	}
 }

--- a/src/test/java/com/appdirect/sdk/vendorFields/controller/VendorFieldValidationControllerTest.java
+++ b/src/test/java/com/appdirect/sdk/vendorFields/controller/VendorFieldValidationControllerTest.java
@@ -1,6 +1,10 @@
 package com.appdirect.sdk.vendorFields.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
@@ -13,7 +17,11 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.web.bind.WebDataBinder;
 
+import com.appdirect.sdk.vendorFields.converter.FlowTypeConverter;
+import com.appdirect.sdk.vendorFields.converter.LocaleConverter;
+import com.appdirect.sdk.vendorFields.converter.OperationTypeConverter;
 import com.appdirect.sdk.vendorFields.handler.VendorFieldValidationHandler;
 import com.appdirect.sdk.vendorFields.model.FlowType;
 import com.appdirect.sdk.vendorFields.model.OperationType;
@@ -26,6 +34,8 @@ import com.google.inject.internal.Maps;
 public class VendorFieldValidationControllerTest {
 	@Mock
 	private VendorFieldValidationHandler mockVendorFieldValidationHandler;
+	@Mock
+	private WebDataBinder webdataBinder;
 
 	private VendorFieldValidationController vendorFieldValidationController;
 
@@ -60,6 +70,15 @@ public class VendorFieldValidationControllerTest {
 
 		//Then
 		assertThat(controllerResponse).isEqualTo(response);
+	}
+
+	@Test
+	public void testInitBinder() {
+		vendorFieldValidationController.initBinder(webdataBinder);
+
+		verify(webdataBinder, times(1)).registerCustomEditor(eq(FlowType.class), any(FlowTypeConverter.class));
+		verify(webdataBinder, times(1)).registerCustomEditor(eq(OperationType.class), any(OperationTypeConverter.class));
+		verify(webdataBinder, times(1)).registerCustomEditor(eq(List.class), any(LocaleConverter.class));
 	}
 }
 


### PR DESCRIPTION
#### Description
- Fix `VendorFieldsValidationController` where InitBinder was missing provoking error parsing Locales. Added UTs to prevent this from happenning

#### Manual merge checklist:
- [x] Code Review completed
- [x] Code coverage
- [x] Approved by a PI tech lead
- [x] Github checks all green

#### Notification(s)
@AppDirect/connectors 

