### PR TITLE
Fixed bug in Locale jdk where Locale is created with invalid tag. Filtering out values with invalid locale

### DIFF
--- a/src/main/java/com/appdirect/sdk/vendorFields/converter/LocaleConverter.java
+++ b/src/main/java/com/appdirect/sdk/vendorFields/converter/LocaleConverter.java
@@ -1,6 +1,7 @@
 package com.appdirect.sdk.vendorFields.converter;
 
 import java.beans.PropertyEditorSupport;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.Locale;
@@ -18,6 +19,7 @@ public class LocaleConverter extends PropertyEditorSupport {
 					.stream()
 					.sorted(Comparator.comparing(Locale.LanguageRange::getWeight).reversed())
 					.map(localeRange -> Locale.forLanguageTag(localeRange.getRange()))
+					.filter(locale -> Arrays.asList(Locale.getAvailableLocales()).contains(locale))
 					.collect(Collectors.toList()));
 		} catch (IllegalArgumentException | NullPointerException e) {
 			throw new PropertyEditorSupportException("Failed to serialize Locale from Accept-Language header with value=%s", text);

--- a/src/test/java/com/appdirect/sdk/vendorFields/converter/LocaleConverterTest.java
+++ b/src/test/java/com/appdirect/sdk/vendorFields/converter/LocaleConverterTest.java
@@ -31,7 +31,7 @@ public class LocaleConverterTest {
 
 	@Test
 	public void testOneLocale() {
-		String localeToParse = "us";
+		String localeToParse = "en";
 		List<Locale> expected = Collections.singletonList(Locale.forLanguageTag(localeToParse));
 
 		localeConverter.setAsText(localeToParse);
@@ -78,6 +78,15 @@ public class LocaleConverterTest {
 		localeConverter.setAsText(localeToParse);
 
 		assertThat(localeConverter.getValue()).isEqualTo(expected);
+	}
+
+	@Test
+	public void testInvalidLocale_isNotIncludedInList() {
+		String localeToParse = "us";
+
+		localeConverter.setAsText(localeToParse);
+
+		assertThat(localeConverter.getValue()).isEqualTo(Collections.emptyList());
 	}
 
 	@Test


### PR DESCRIPTION
#### Description
- `Locale.forLanguageTag()` is not validating if the parameter is valid. Therefore, we need to manually iterate over all available locales and validate if the locale is valid (otherwise drop it).

#### Manual merge checklist:
- [x] Code Review completed
- [ ] Code coverage
- [ ] QA Validation completed
  - Testrail TestCase/Plan link:
- [ ] Approved by a PI tech lead
- [ ] Github checks all green

#### Notification(s)


