### PR TITLE
PI-16557/16556: Added eventId and eventDate to usageItem

### DIFF
--- a/src/main/java/com/appdirect/sdk/meteredusage/model/UsageItem.java
+++ b/src/main/java/com/appdirect/sdk/meteredusage/model/UsageItem.java
@@ -1,6 +1,7 @@
 package com.appdirect.sdk.meteredusage.model;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.Currency;
 import java.util.Map;
 
@@ -11,6 +12,7 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 import com.appdirect.sdk.appmarket.events.PricingUnit;
+import com.fasterxml.jackson.annotation.JsonFormat;
 
 @Builder
 @Data
@@ -25,5 +27,8 @@ public class UsageItem {
 	private String description;
 	private Currency currency;
 	private Map<String, String> attributes;
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "MM-dd-yyyy hh:mm:ss")
+	private LocalDateTime eventDate;
+	private String eventId;
 }
 

--- a/src/test/java/com/appdirect/sdk/meteredusage/mother/UsageItemMother.java
+++ b/src/test/java/com/appdirect/sdk/meteredusage/mother/UsageItemMother.java
@@ -18,6 +18,8 @@ public class UsageItemMother {
 				.currency(Currency.getInstance(Locale.US))
 				.customUnit(ConstantUtils.CUSTOM_UNIT)
 				.pricingUnit(PricingUnit.UNIT)
-				.attributes(Maps.newHashMap());
+				.attributes(Maps.newHashMap())
+				.eventDate(ConstantUtils.EVENT_DATE)
+				.eventId(ConstantUtils.EVENT_ID);
 	}
 }

--- a/src/test/java/com/appdirect/sdk/utils/ConstantUtils.java
+++ b/src/test/java/com/appdirect/sdk/utils/ConstantUtils.java
@@ -1,5 +1,7 @@
 package com.appdirect.sdk.utils;
 
+import java.time.LocalDateTime;
+
 public class ConstantUtils {
 	public static final String BASE_URL = "https://localhost:8080/";
 	public static final String CONSUMER_KEY = "ConsumerKey";
@@ -14,4 +16,7 @@ public class ConstantUtils {
 
 	public static final String ATTRIBUTE_KEY = "AttributeKey";
 	public static final String ATTRIBUTE_VALUE = "AttributeValue";
+
+	public static final LocalDateTime EVENT_DATE = LocalDateTime.now();
+	public static final String EVENT_ID = "EventId";
 }


### PR DESCRIPTION
#### [PI-16556](https://appdirect.jira.com/browse/PI-16556)
#### [PI-16557](https://appdirect.jira.com/browse/PI-16557)

#### Description
The field eventDate was added to metered-usage service API contract.
The field eventId was added to metered-usage service API contract

#### Manual merge checklist:
- [x] Code Review completed
- [ ] Code coverage
- [ ] QA Validation completed
  - Testrail TestCase/Plan link:
- [ ] Approved by a PI tech lead
- [x] Github checks all green

#### Notification(s)
@AppDirect/connectors 

