### PR TITLE
Fixing eventDate serialization for UsageItem

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,14 @@
             <artifactId>converter-jackson</artifactId>
             <version>2.4.0</version>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>2.6.1</version>
+        </dependency>
+
     </dependencies>
+    
 
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -161,9 +161,7 @@
             <artifactId>jackson-datatype-jsr310</artifactId>
             <version>2.6.1</version>
         </dependency>
-
     </dependencies>
-    
 
     <build>
         <plugins>

--- a/src/main/java/com/appdirect/sdk/meteredusage/model/UsageItem.java
+++ b/src/main/java/com/appdirect/sdk/meteredusage/model/UsageItem.java
@@ -15,6 +15,8 @@ import org.springframework.format.annotation.DateTimeFormat;
 
 import com.appdirect.sdk.appmarket.events.PricingUnit;
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 
 @Builder
 @Data
@@ -29,8 +31,8 @@ public class UsageItem {
 	private String description;
 	private Currency currency;
 	private Map<String, String> attributes;
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSZ")
-	@DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSZ")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss.SSS")
+	@JsonSerialize(using = LocalDateTimeSerializer.class)
 	private LocalDateTime eventDate;
 	private String eventId;
 }


### PR DESCRIPTION
#### Description
- `eventDate` is being serialized as an object (with `dayOfMonth`, `year`, `calendar`, etc). This PR fixes the serialization.

#### Manual merge checklist:
- [x] Code Review completed
- [x] Code coverage
- [x] Approved by a PI tech lead
- [x] Github checks all green

#### Notification(s)


