### PR TITLE
PI-16726: Reformat eventDate to 2019-10-23T09:39:12.569Z or similar

### DIFF
--- a/src/main/java/com/appdirect/sdk/meteredusage/model/UsageItem.java
+++ b/src/main/java/com/appdirect/sdk/meteredusage/model/UsageItem.java
@@ -31,7 +31,7 @@ public class UsageItem {
 	private String description;
 	private Currency currency;
 	private Map<String, String> attributes;
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss.SSS")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSZ")
 	@JsonSerialize(using = LocalDateTimeSerializer.class)
 	private LocalDateTime eventDate;
 	private String eventId;

--- a/src/main/java/com/appdirect/sdk/meteredusage/model/UsageItem.java
+++ b/src/main/java/com/appdirect/sdk/meteredusage/model/UsageItem.java
@@ -1,7 +1,7 @@
 package com.appdirect.sdk.meteredusage.model;
 
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.Currency;
 import java.util.Map;
 
@@ -11,18 +11,15 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
-import org.springframework.format.annotation.DateTimeFormat;
-
 import com.appdirect.sdk.appmarket.events.PricingUnit;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.ZonedDateTimeSerializer;
 
 @Builder
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-@ToString
 public class UsageItem {
 	private PricingUnit pricingUnit;
 	private String customUnit;
@@ -31,9 +28,9 @@ public class UsageItem {
 	private String description;
 	private Currency currency;
 	private Map<String, String> attributes;
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSZ")
-	@JsonSerialize(using = LocalDateTimeSerializer.class)
-	private LocalDateTime eventDate;
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+	@JsonSerialize(using = ZonedDateTimeSerializer.class)
+	private ZonedDateTime eventDate;
 	private String eventId;
 }
 

--- a/src/test/java/com/appdirect/sdk/utils/ConstantUtils.java
+++ b/src/test/java/com/appdirect/sdk/utils/ConstantUtils.java
@@ -1,6 +1,6 @@
 package com.appdirect.sdk.utils;
 
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 
 public class ConstantUtils {
 	public static final String BASE_URL = "https://localhost:8080/";
@@ -17,6 +17,6 @@ public class ConstantUtils {
 	public static final String ATTRIBUTE_KEY = "AttributeKey";
 	public static final String ATTRIBUTE_VALUE = "AttributeValue";
 
-	public static final LocalDateTime EVENT_DATE = LocalDateTime.now();
+	public static final ZonedDateTime EVENT_DATE = ZonedDateTime.now();
 	public static final String EVENT_ID = "EventId";
 }


### PR DESCRIPTION
#### [PI-16726](https://appdirect.jira.com/browse/PI-16726)

#### Description
- Reformat eventDate to 2019-10-23T09:39:12.569Z or similar. In order to achieve that, we need to store the ZoneId in the entity, therefore we need a ZonedDateTime for it.

#### Manual merge checklist:
- [ ] Code Review completed
- [ ] Code coverage
- [ ] QA Validation completed
  - Testrail TestCase/Plan link:
- [ ] Approved by a PI tech lead
- [ ] Github checks all green

#### Notification(s)
@AppDirect/connectors 