### PR TITLE
Change zipkin version to be the same used by appdirect

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
         <dependency>
             <groupId>io.zipkin.brave</groupId>
             <artifactId>brave-instrumentation-okhttp3</artifactId>
-            <version>5.6.9</version>
+            <version>5.1.0</version>
         </dependency>
         <!-- Testing -->
         <dependency>


### PR DESCRIPTION
#### Description
- There is an error in one of the services using the AppDirect Libraries that are using an older version from Zipkin, provoking the service to not boot. `5.6.9` decreased into `5.1.0`.
- Result from `mvn dependency:tree`.
_In the SDK_
```
[INFO] |  +- io.zipkin.brave:brave-instrumentation-okhttp3:jar:5.6.9:compile
[INFO] |  |  +- io.zipkin.brave:brave-instrumentation-http:jar:5.6.9:compile
[INFO] |  |  \- io.zipkin.brave:brave:jar:5.6.9:compile
[INFO] |  |     +- io.zipkin.zipkin2:zipkin:jar:2.15.0:compile
[INFO] |  |     \- io.zipkin.reporter2:zipkin-reporter:jar:2.10.0:compile
```
_In the AppDirect Library_
```
[INFO] |  +- com.appdirect.boot:appdirect-boot-tracing-core:jar:0.3.4:compile
[INFO] |  |  \- io.zipkin.reporter2:zipkin-sender-okhttp3:jar:2.7.3:compile
[INFO] |  +- io.zipkin.brave:brave-instrumentation-servlet:jar:5.1.0:compile
[INFO] |  \- io.zipkin.brave:brave-instrumentation-spring-web:jar:5.1.0:compile
[INFO] +- com.appdirect.boot:tracing-rabbitmq-starter:jar:0.3.4:compile
[INFO] |  \- io.zipkin.brave:brave-instrumentation-spring-rabbit:jar:5.1.0:compile
[INFO] +- com.appdirect.boot:tracing-httpclient-starter:jar:0.3.4:compile
[INFO] |  \- io.zipkin.brave:brave-instrumentation-httpclient:jar:5.1.0:compile
```

#### Manual merge checklist:
- [x] Code Review completed
- [ ] Code coverage
- [ ] QA Validation completed
  - Testrail TestCase/Plan link:
- [ ] Approved by a PI tech lead
- [x] Github checks all green

#### Notification(s)
@AppDirect/connectors 