### PR TITLE
Adding EncryptedFieldConverter to reuse from multiple services

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,6 +174,12 @@
             <artifactId>jackson-datatype-jsr310</artifactId>
             <version>2.6.1</version>
         </dependency>
+        <dependency>
+            <groupId>javax.persistence</groupId>
+            <artifactId>javax.persistence-api</artifactId>
+            <version>2.2</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/java/com/appdirect/sdk/security/encryption/configuration/EncryptionConfiguration.java
+++ b/src/main/java/com/appdirect/sdk/security/encryption/configuration/EncryptionConfiguration.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Configuration;
 
 import com.appdirect.sdk.security.encryption.EncryptDeserialize;
 import com.appdirect.sdk.security.encryption.EncryptSerialize;
+import com.appdirect.sdk.security.encryption.converter.EncryptedFieldConverter;
 import com.appdirect.sdk.security.encryption.service.AESEncryptionServiceImpl;
 import com.appdirect.sdk.security.encryption.service.EncryptionService;
 
@@ -30,5 +31,10 @@ public class EncryptionConfiguration {
 	@Bean
 	public EncryptionService encryptionService() {
 		return new AESEncryptionServiceImpl(key, initVector);
+	}
+
+	@Bean
+	public EncryptedFieldConverter encryptedFieldConverter() {
+		return new EncryptedFieldConverter();
 	}
 }

--- a/src/main/java/com/appdirect/sdk/security/encryption/converter/EncryptedFieldConverter.java
+++ b/src/main/java/com/appdirect/sdk/security/encryption/converter/EncryptedFieldConverter.java
@@ -1,0 +1,48 @@
+package com.appdirect.sdk.security.encryption.converter;
+
+import java.util.Objects;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.appdirect.sdk.security.encryption.service.EncryptionService;
+
+@Slf4j
+@Component
+@Converter
+public class EncryptedFieldConverter implements AttributeConverter<String, String> {
+	private static final String MASK_PATTERN = "(?<=.{4})(.*)$";
+	private static final String MASK = "***";
+
+	private static EncryptionService encryptionService;
+
+	@Autowired
+	public void init(EncryptionService encryptionService) {
+		EncryptedFieldConverter.encryptionService = encryptionService;
+	}
+
+	@Override
+	public String convertToDatabaseColumn(String value) {
+		try {
+			return Objects.nonNull(value) ? encryptionService.encrypt(value) : null;
+		} catch (Exception e) {
+			log.warn("Unable to encrypt data to database, storing plain value={}", value.replaceAll(MASK_PATTERN, MASK));
+			return value;
+		}
+	}
+
+	@Override
+	public String convertToEntityAttribute(String value) {
+		try {
+			return Objects.nonNull(value) ? encryptionService.decrypt(value) : null;
+		} catch (Exception e) {
+			log.warn("Unable to decrypt data from database, retrieving plain value={}", value.replaceAll(MASK_PATTERN, MASK));
+			return value;
+		}
+	}
+}

--- a/src/test/java/com/appdirect/sdk/security/encryption/EncryptedFieldConverterTest.java
+++ b/src/test/java/com/appdirect/sdk/security/encryption/EncryptedFieldConverterTest.java
@@ -1,0 +1,54 @@
+package com.appdirect.sdk.security.encryption;
+
+import static com.appdirect.sdk.utils.ConstantUtils.ENCRYPTED_DATA;
+import static com.appdirect.sdk.utils.ConstantUtils.TEST_ENCRYPTION_DATA;
+import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.appdirect.sdk.security.encryption.converter.EncryptedFieldConverter;
+import com.appdirect.sdk.security.encryption.service.EncryptionService;
+
+public class EncryptedFieldConverterTest {
+	@Mock
+	private EncryptionService encryptionService;
+
+	private EncryptedFieldConverter encryptedFieldConverter;
+
+	@BeforeMethod
+	public void setup() {
+		MockitoAnnotations.initMocks(this);
+		encryptedFieldConverter = new EncryptedFieldConverter();
+		ReflectionTestUtils.setField(encryptedFieldConverter, "encryptionService", encryptionService);
+	}
+
+	@Test
+	public void testConvertToDatabaseColumn() {
+		when(encryptionService.encrypt(TEST_ENCRYPTION_DATA)).thenReturn(ENCRYPTED_DATA);
+		ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
+
+		encryptedFieldConverter.convertToDatabaseColumn(TEST_ENCRYPTION_DATA);
+
+		verify(encryptionService, times(1)).encrypt(argumentCaptor.capture());
+		assertThat(TEST_ENCRYPTION_DATA).isEqualTo(argumentCaptor.getValue());
+	}
+
+	@Test
+	public void testConvertToEntityAttribute() {
+		when(encryptionService.decrypt(ENCRYPTED_DATA)).thenReturn(TEST_ENCRYPTION_DATA);
+		ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
+
+		encryptedFieldConverter.convertToEntityAttribute(ENCRYPTED_DATA);
+
+		verify(encryptionService, times(1)).decrypt(argumentCaptor.capture());
+		assertThat(ENCRYPTED_DATA).isEqualTo(argumentCaptor.getValue());
+	}
+}


### PR DESCRIPTION
#### Description
- Adding a `EncryptedFieldConverter` and exposing it through `EncryptionConfiguration`. This `Component` can be used to encrypt/decrypt attributes from a Entity that need to be encrypted.

#### Manual merge checklist:
- [x] Code Review completed
- [x] Code coverage
- [ ] QA Validation completed
  - Testrail TestCase/Plan link:
- [ ] Approved by a PI tech lead
- [x] Github checks all green

#### Notification(s)
@AppDirect/connectors 