### PR TITLE
PI-17602 Add subscriptionId field to MeteredUsageItem

### DIFF
--- a/src/main/java/com/appdirect/sdk/meteredusage/model/MeteredUsageItem.java
+++ b/src/main/java/com/appdirect/sdk/meteredusage/model/MeteredUsageItem.java
@@ -8,12 +8,16 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
 @Builder
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 public class MeteredUsageItem {
 	private String accountId;
+	@JsonInclude(Include.NON_NULL)
+	private String subscriptionId;
 	private List<UsageItem> usageList = new ArrayList<>();
 }
-

--- a/src/test/java/com/appdirect/sdk/meteredusage/mother/MeteredUsageItemMother.java
+++ b/src/test/java/com/appdirect/sdk/meteredusage/mother/MeteredUsageItemMother.java
@@ -12,6 +12,6 @@ public class MeteredUsageItemMother {
 	}
 
 	public static MeteredUsageItem.MeteredUsageItemBuilder withSubscriptionId() {
-		return basic().usageList(Lists.newArrayList(UsageItemMother.basic().build()));
+		return basic().subscriptionId(ConstantUtils.SUBSCRIPTION_ID);
 	}
 }

--- a/src/test/java/com/appdirect/sdk/meteredusage/mother/MeteredUsageItemMother.java
+++ b/src/test/java/com/appdirect/sdk/meteredusage/mother/MeteredUsageItemMother.java
@@ -12,9 +12,6 @@ public class MeteredUsageItemMother {
 	}
 
 	public static MeteredUsageItem.MeteredUsageItemBuilder withSubscriptionId() {
-		return MeteredUsageItem.builder()
-			.accountId(ConstantUtils.ACCOUNT_ID)
-			.subscriptionId(ConstantUtils.SUBSCRIPTION_ID)
-			.usageList(Lists.newArrayList(UsageItemMother.basic().build()));
+		return basic().usageList(Lists.newArrayList(UsageItemMother.basic().build()));
 	}
 }

--- a/src/test/java/com/appdirect/sdk/meteredusage/mother/MeteredUsageItemMother.java
+++ b/src/test/java/com/appdirect/sdk/meteredusage/mother/MeteredUsageItemMother.java
@@ -10,4 +10,11 @@ public class MeteredUsageItemMother {
 				.accountId(ConstantUtils.ACCOUNT_ID)
 				.usageList(Lists.newArrayList(UsageItemMother.basic().build()));
 	}
+
+	public static MeteredUsageItem.MeteredUsageItemBuilder withSubscriptionId() {
+		return MeteredUsageItem.builder()
+			.accountId(ConstantUtils.ACCOUNT_ID)
+			.subscriptionId(ConstantUtils.SUBSCRIPTION_ID)
+			.usageList(Lists.newArrayList(UsageItemMother.basic().build()));
+	}
 }

--- a/src/test/java/com/appdirect/sdk/meteredusage/service/MeteredUsageApiClientServiceTest.java
+++ b/src/test/java/com/appdirect/sdk/meteredusage/service/MeteredUsageApiClientServiceTest.java
@@ -7,6 +7,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.Before;
@@ -23,12 +26,14 @@ import com.appdirect.sdk.meteredusage.MeteredUsageApi;
 import com.appdirect.sdk.meteredusage.RetrofitCallStub;
 import com.appdirect.sdk.meteredusage.config.OAuth1RetrofitWrapper;
 import com.appdirect.sdk.meteredusage.model.MeteredUsageItem;
+import com.appdirect.sdk.meteredusage.model.MeteredUsageRequest;
 import com.appdirect.sdk.meteredusage.model.MeteredUsageResponse;
 import com.appdirect.sdk.meteredusage.mother.MeteredUsageItemMother;
 import com.appdirect.sdk.utils.ConstantUtils;
 import com.google.inject.internal.Lists;
 import okhttp3.MediaType;
 import okhttp3.ResponseBody;
+import okio.Buffer;
 import retrofit2.Call;
 import retrofit2.Response;
 
@@ -148,6 +153,51 @@ public class MeteredUsageApiClientServiceTest {
 		APIResult result = meteredUsageApiClientService.reportUsage(ConstantUtils.BASE_URL, ConstantUtils.IDEMPOTENCY_KEY, items, ConstantUtils.BILLABLE, ConstantUtils.CONSUMER_KEY, null, ConstantUtils.EMPTY_SOURCE_TYPE);
 
 		assertThat(result.isSuccess()).isFalse();
+	}
+
+	@Test
+	public void testSendSubscriptionIdInMeteredUsageItem_getsSerialized() {
+
+		Call<MeteredUsageResponse> call = buildCall(MeteredUsageItemMother.withSubscriptionId().build());
+		String body = getCallBodyAsAString(call);
+
+		assertThat(body).isNotNull();
+		assertThat(body).contains(ConstantUtils.SUBSCRIPTION_ID);
+	}
+
+	@Test
+	public void testDONTSendSubscriptionIdInMeteredItem_doesntGetSerialized() {
+
+		Call<MeteredUsageResponse> call = buildCall(MeteredUsageItemMother.basic().build());
+		String body = getCallBodyAsAString(call);
+
+		assertThat(body).isNotNull();
+		assertThat(body).doesNotContain(ConstantUtils.SUBSCRIPTION_ID);
+	}
+
+	private Call<MeteredUsageResponse> buildCall(MeteredUsageItem meteredUsageItem) {
+		MeteredUsageApi meteredUsageApi = meteredUsageApiClientService.createMeteredUsageApi(ConstantUtils.BASE_URL, ConstantUtils.CONSUMER_KEY, ConstantUtils.CONSUMER_SECRET);
+		MeteredUsageRequest meteredUsageRequest = MeteredUsageRequest.builder()
+			.idempotencyKey(ConstantUtils.IDEMPOTENCY_KEY)
+			.billable(ConstantUtils.BILLABLE)
+			.usages(Collections.singletonList(meteredUsageItem))
+			.sourceType(ConstantUtils.SOURCE_TYPE)
+			.build();
+		return meteredUsageApi.meteredUsageCall(meteredUsageRequest);
+	}
+
+	private String getCallBodyAsAString(Call<MeteredUsageResponse> call) {
+		String body = null;
+		try {
+			Buffer buffer = new Buffer();
+			ByteArrayOutputStream stream = new ByteArrayOutputStream();
+			call.request().body().writeTo(buffer);
+			buffer.copyTo(stream);
+			body = new String(stream.toByteArray());
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+		return body;
 	}
 
 	private Response<MeteredUsageResponse> buildResponse(MeteredUsageResponse meteredUsageResponse) {

--- a/src/test/java/com/appdirect/sdk/utils/ConstantUtils.java
+++ b/src/test/java/com/appdirect/sdk/utils/ConstantUtils.java
@@ -13,6 +13,7 @@ public class ConstantUtils {
 	public static final String REQUEST_ID = "RequestId";
 
 	public static final String ACCOUNT_ID = "AccountId";
+	public static final String SUBSCRIPTION_ID = "SubscriptionId";
 
 	public static final String DESCRIPTION = "Description";
 	public static final String CUSTOM_UNIT = "PC";


### PR DESCRIPTION
#### [PI-17602](https://appdirect.jira.com/browse/PI-17602)

#### Description
This PR adds a subscriptionId field to the MeteredUsageItem class to account for changes in Metered Usage API. It's been annotated not to get serialized into Json when its null, to avoid breaking flows that don't need it. 

#### Manual merge checklist:
- [x] Code Review completed
- [ ] Code coverage
- [ ] QA Validation completed
  - Testrail TestCase/Plan link:
- [ ] Approved by a PI tech lead
- [x] Github checks all green

#### Notification(s)


