### PR TITLE
PI-17602 FIX: Backwards compatibility for MeteredUsageItem

### DIFF
--- a/src/main/java/com/appdirect/sdk/meteredusage/model/MeteredUsageItem.java
+++ b/src/main/java/com/appdirect/sdk/meteredusage/model/MeteredUsageItem.java
@@ -20,4 +20,9 @@ public class MeteredUsageItem {
 	@JsonInclude(Include.NON_NULL)
 	private String subscriptionId;
 	private List<UsageItem> usageList = new ArrayList<>();
+
+	public MeteredUsageItem(String accountId, List<UsageItem> usageList) {
+		this.accountId = accountId;
+		this.usageList = usageList;
+	}
 }

--- a/src/test/java/com/appdirect/sdk/meteredusage/service/MeteredUsageApiClientServiceTest.java
+++ b/src/test/java/com/appdirect/sdk/meteredusage/service/MeteredUsageApiClientServiceTest.java
@@ -166,7 +166,7 @@ public class MeteredUsageApiClientServiceTest {
 	}
 
 	@Test
-	public void testDONTSendSubscriptionIdInMeteredItem_doesntGetSerialized() {
+	public void testDONTSendSubscriptionIdInMeteredUsageItem_doesntGetSerialized() {
 
 		Call<MeteredUsageResponse> call = buildCall(MeteredUsageItemMother.basic().build());
 		String body = getCallBodyAsAString(call);


### PR DESCRIPTION
#### [PI-17602](https://appdirect.jira.com/browse/PI-17602)

#### Description
This PR adds a constructor to the MeteredUsageItem class with only the fields it used to have, in order not to break clients that were using older versions of it.

#### Manual merge checklist:
- [x] Code Review completed
- [ ] Approved by a PI tech lead
- [x] Github checks all green

#### Notification(s)

