### PR TITLE
PI-17312: Updated hateos version and fix SubscriptionOrderEventParser issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,7 @@
         <dependency>
             <groupId>org.springframework.hateoas</groupId>
             <artifactId>spring-hateoas</artifactId>
+            <version>1.0.3.RELEASE</version>
         </dependency>
         <!-- Guava -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,6 @@
         <dependency>
             <groupId>org.springframework.hateoas</groupId>
             <artifactId>spring-hateoas</artifactId>
-            <version>1.0.3.RELEASE</version>
         </dependency>
         <!-- Guava -->
         <dependency>

--- a/src/main/java/com/appdirect/sdk/appmarket/events/SubscriptionOrderEventParser.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/events/SubscriptionOrderEventParser.java
@@ -13,15 +13,23 @@
 
 package com.appdirect.sdk.appmarket.events;
 
+import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.hateoas.Link;
 
 /**
  * To see what is mandatory or not, consult https://docs.appdirect.com/developer/distribution/event-notifications/subscription-events#attributes
  */
+@Slf4j
 class SubscriptionOrderEventParser implements EventParser<SubscriptionOrder> {
 	@Override
 	public SubscriptionOrder parse(EventInfo eventInfo, EventHandlingContext eventContext) {
-		String samlIdpUrl = eventInfo.getLinks().stream().filter(link -> link.getRel().equals("samlIdp")).findFirst().map(Link::getHref).orElse(null);
+		String samlIdpUrl = null;
+		try {
+			samlIdpUrl = eventInfo.getLinks().stream().filter(link -> link.getRel().value().equals("samlIdp")).findFirst().map(Link::getHref).orElse(null);
+		} catch (Exception e) {
+			log.warn("Error when recovering samlIdp, proceeding with empty value", e);
+		}
 
 		return new SubscriptionOrder(
 				eventContext.getConsumerKeyUsedByTheRequest(),

--- a/src/main/java/com/appdirect/sdk/appmarket/events/SubscriptionOrderEventParser.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/events/SubscriptionOrderEventParser.java
@@ -26,7 +26,7 @@ class SubscriptionOrderEventParser implements EventParser<SubscriptionOrder> {
 	public SubscriptionOrder parse(EventInfo eventInfo, EventHandlingContext eventContext) {
 		String samlIdpUrl = null;
 		try {
-			samlIdpUrl = eventInfo.getLinks().stream().filter(link -> link.getRel().value().equals("samlIdp")).findFirst().map(Link::getHref).orElse(null);
+			samlIdpUrl = eventInfo.getLinks().stream().filter(link -> link.getRel().equals("samlIdp")).findFirst().map(Link::getHref).orElse(null);
 		} catch (Exception e) {
 			log.warn("Error when recovering samlIdp, proceeding with empty value", e);
 		}


### PR DESCRIPTION
#### [PI-17312](https://appdirect.jira.com/browse/PI-17312)

#### Description
Fixed issue in the SDK that caused MP event to failed due to old dependency version.

#### Manual merge checklist:
- [x] Code Review completed
- [x] Code coverage
- [x] QA Validation completed
  - Testrail TestCase/Plan link:
- [x] Approved by a PI tech lead
- [x] Github checks all green

#### Notification(s)
@AppDirect/connectors 