### PR TITLE
PI-18691: adding FreeTrialInfo class to OrderInfo

### DIFF
--- a/src/main/java/com/appdirect/sdk/appmarket/events/FreeTrialInfo.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/events/FreeTrialInfo.java
@@ -3,7 +3,6 @@ package com.appdirect.sdk.appmarket.events;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 @Data
@@ -11,6 +10,5 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class FreeTrialInfo {
-
   private Boolean active;
 }

--- a/src/main/java/com/appdirect/sdk/appmarket/events/FreeTrialInfo.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/events/FreeTrialInfo.java
@@ -1,0 +1,16 @@
+package com.appdirect.sdk.appmarket.events;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class FreeTrialInfo {
+
+  private Boolean active;
+}

--- a/src/main/java/com/appdirect/sdk/appmarket/events/OrderInfo.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/events/OrderInfo.java
@@ -39,4 +39,5 @@ public class OrderInfo {
 	private List<OrderItemInfo> items = new ArrayList<>();
 	private List<CustomAttribute> customAttributes;
 	private String discountCode;
+	private FreeTrialInfo freeTrial;
 }


### PR DESCRIPTION
#### [PI-18691](https://appdirect.jira.com/browse/PI-18691)

#### Dependencies
N/A

#### Description
Adding FreeTrialInfo class in OrderInfo to support G suite free trial as per https://appdirect.jira.com/wiki/spaces/PI/pages/1108542589/TD+PI-18513+-+G+Suite+Free+Trial

#### Manual merge checklist:
- [ ] Code Review completed
- [ ] Code coverage
- [ ] QA Validation completed
  - Testrail TestCase/Plan link:
- [ ] Approved by a PI tech lead
- [ ] Github checks all green

#### Notification(s)


