### PR TITLE
Exclude MeterUsageServiceException from retryable

### DIFF
--- a/src/main/java/com/appdirect/sdk/meteredusage/service/MeteredUsageApiClientService.java
+++ b/src/main/java/com/appdirect/sdk/meteredusage/service/MeteredUsageApiClientService.java
@@ -7,6 +7,7 @@ import org.springframework.retry.annotation.Retryable;
 
 import com.appdirect.sdk.appmarket.events.APIResult;
 import com.appdirect.sdk.appmarket.events.AppmarketBillingClient;
+import com.appdirect.sdk.meteredusage.exception.MeterUsageServiceException;
 import com.appdirect.sdk.meteredusage.exception.MeteredUsageApiException;
 import com.appdirect.sdk.meteredusage.exception.ServiceException;
 import com.appdirect.sdk.meteredusage.model.MeteredUsageItem;
@@ -178,6 +179,7 @@ public interface MeteredUsageApiClientService {
 
 	@Retryable(
 			value = {ServiceException.class, MeteredUsageApiException.class, RuntimeException.class},
+			exclude = {MeterUsageServiceException.class},
 			maxAttemptsExpression = "#{${usage.api.retry.maxAttempts:3}}",
 			backoff = @Backoff(delayExpression = "#{${usage.api.retry.backoff.delay:2000}}",
 					multiplierExpression = "#{${usage.api.retry.backoff.multiplier:2}}",


### PR DESCRIPTION
#### [PI-19617](https://appdirect.jira.com/browse/PI-19617)

#### Description
When Usages are already reported to MUV2 we get 400 error having idempotency key error. We should not make a retry again to report Usages if they are already reported.

#### Manual merge checklist:
- [ ] Code Review completed
- [ ] Code coverage
- [ ] QA Validation completed
  - Testrail TestCase/Plan link:
- [ ] Approved by a PI tech lead
- [ ] Github checks all green

