### PR TITLE
PI-20330 Add Context to VRF response

### DIFF
--- a/src/main/java/com/appdirect/sdk/vendorFields/model/Context.java
+++ b/src/main/java/com/appdirect/sdk/vendorFields/model/Context.java
@@ -1,5 +1,6 @@
 package com.appdirect.sdk.vendorFields.model;
 
 public enum Context {
-    CART_LEVEL
+    CART_LEVEL,
+    ITEM_LEVEL
 }

--- a/src/main/java/com/appdirect/sdk/vendorFields/model/v2/VendorRequiredFieldsResponseV2.java
+++ b/src/main/java/com/appdirect/sdk/vendorFields/model/v2/VendorRequiredFieldsResponseV2.java
@@ -14,5 +14,4 @@ public class VendorRequiredFieldsResponseV2 {
     private String isvIdentifier;
     private List<VendorRequiredFieldV2> fields;
     private Context context;
-
 }

--- a/src/main/java/com/appdirect/sdk/vendorFields/model/v2/VendorRequiredFieldsResponseV2.java
+++ b/src/main/java/com/appdirect/sdk/vendorFields/model/v2/VendorRequiredFieldsResponseV2.java
@@ -1,6 +1,8 @@
 package com.appdirect.sdk.vendorFields.model.v2;
 
 import java.util.List;
+
+import com.appdirect.sdk.vendorFields.model.Context;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -11,4 +13,6 @@ import lombok.Data;
 public class VendorRequiredFieldsResponseV2 {
     private String isvIdentifier;
     private List<VendorRequiredFieldV2> fields;
+    private Context context;
+
 }

--- a/src/test/java/com/appdirect/sdk/vendorFields/controller/VendorRequiredFieldsControllerTest.java
+++ b/src/test/java/com/appdirect/sdk/vendorFields/controller/VendorRequiredFieldsControllerTest.java
@@ -25,6 +25,7 @@ import com.appdirect.sdk.vendorFields.converter.FlowTypeConverter;
 import com.appdirect.sdk.vendorFields.converter.LocaleConverter;
 import com.appdirect.sdk.vendorFields.converter.OperationTypeConverter;
 import com.appdirect.sdk.vendorFields.handler.VendorRequiredFieldHandler;
+import com.appdirect.sdk.vendorFields.model.Context;
 import com.appdirect.sdk.vendorFields.model.FieldType;
 import com.appdirect.sdk.vendorFields.model.FlowType;
 import com.appdirect.sdk.vendorFields.model.Form;
@@ -123,7 +124,7 @@ public class VendorRequiredFieldsControllerTest {
                 .validations(validations)
                 .options(options)
                 .build();
-        final VendorRequiredFieldsResponseV2 response = new VendorRequiredFieldsResponseV2("isvIdentifier", Collections.singletonList(vendorRequiredFieldV2));
+        final VendorRequiredFieldsResponseV2 response = new VendorRequiredFieldsResponseV2("isvIdentifier", Collections.singletonList(vendorRequiredFieldV2), Context.CART_LEVEL);
         when(mockVendorRequiredFieldHandlerV2.getRequiredFields(
                 "SKU",
                 "editionId",


### PR DESCRIPTION
#### [PI-20330](https://appdirect.jira.com/browse/PI-20330)

#### Description
Add Context to VendorRequiredFieldsResponseV2 as we need to have the option to return context so that RFS and determine whether to return item-level or cart-level to the UI

#### Manual merge checklist:
- [ ] Code Review completed
- [ ] Code coverage
- [ ] QA Validation completed
  - Testrail TestCase/Plan link:
- [ ] Approved by a PI tech lead
- [ ] Github checks all green

#### Notification(s)


