### PR TITLE
PI-21145  : Making request body as optional for Order Validation

### DIFF
--- a/src/main/java/com/appdirect/sdk/appmarket/validation/AppmarketOrderValidationController.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/validation/AppmarketOrderValidationController.java
@@ -17,6 +17,9 @@ import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED_VAL
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.web.bind.annotation.RequestMethod.POST;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -43,7 +46,11 @@ public class AppmarketOrderValidationController {
 			consumes = APPLICATION_FORM_URLENCODED_VALUE,
 			produces = APPLICATION_JSON_VALUE
 	)
-	ValidationResponse validateOrderFields(@RequestBody MultiValueMap<String, String> body) {
-		return validationHandler.validateOrderFields(body.toSingleValueMap());
+	ValidationResponse validateOrderFields(@RequestBody(required = false) MultiValueMap<String, String> body) {
+		Map<String, String> params = new HashMap<>();
+		if (null != body) {
+			params = body.toSingleValueMap();
+		}
+		return validationHandler.validateOrderFields(params);
 	}
 }


### PR DESCRIPTION
#### [PI-21145](https://appdirect.jira.com/browse/PI-21145 )

#### Description
With Checkout V2 flow, When the PRF fields are having empty values, empty requestBody is sent to validation endpoint(/unsecured/integration/orderValidation).
Making RequestBody optional for this endpoint.

#### Manual merge checklist:
- [ ] Code Review completed
- [ ] Code coverage
- [ ] QA Validation completed
  - Testrail TestCase/Plan link:
- [ ] Approved by a PI tech lead
- [ ] Github checks all green

