### PR TITLE
Updating SDK version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <groupId>com.appdirect</groupId>
     <artifactId>service-integration-sdk</artifactId>
     <packaging>jar</packaging>
-    <version>1.121-SNAPSHOT</version>
+    <version>1.122-SNAPSHOT</version>
     <name>SDK for service integration</name>
 
     <properties>


### PR DESCRIPTION

#### Description
SDK Jenkins build is failing for SDK tag
Updating SDK version to 122

Git::GitExecuteError: git '--git-dir=/var/****/workspace/service-integration-sdk-0/.git' '--work-tree=/var/****/workspace/service-integration-sdk-0' tag '1.121' '-m Tag for 1.121'  2>&1:fatal: **tag '1.121' already exists**

https://pi.ci.appdirect.tools/job/service-integration-sdk-release-dsl/109/console


#### Manual merge checklist:
- [ ] Code Review completed
- [ ] Code coverage
- [ ] QA Validation completed
  - Testrail TestCase/Plan link:
- [ ] Approved by a PI tech lead
- [ ] Github checks all green

#### Notification(s)


