### PR TITLE
GOOG-1816: updating VendorRequiredFieldV2 payload for SDK V2 version

### DIFF
--- a/src/main/java/com/appdirect/sdk/vendorFields/model/v2/Options.java
+++ b/src/main/java/com/appdirect/sdk/vendorFields/model/v2/Options.java
@@ -11,5 +11,5 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class Options {
     private Suffix suffix;
-    private String placeholderKey;
+    private String placeholder;
 }

--- a/src/main/java/com/appdirect/sdk/vendorFields/model/v2/VendorRequiredFieldV2.java
+++ b/src/main/java/com/appdirect/sdk/vendorFields/model/v2/VendorRequiredFieldV2.java
@@ -11,9 +11,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class VendorRequiredFieldV2 {
     private String inputCode;
-    private String inputTitleKey;
-    private String subTitleKey;
-    private String tooltipKey;
+    private String inputTitle;
+    private String subTitle;
+    private String tooltip;
     private String value;
     private FieldTypeV2 fieldType;
     private Validations validations;

--- a/src/test/java/com/appdirect/sdk/vendorFields/controller/VendorRequiredFieldsControllerTest.java
+++ b/src/test/java/com/appdirect/sdk/vendorFields/controller/VendorRequiredFieldsControllerTest.java
@@ -112,13 +112,13 @@ public class VendorRequiredFieldsControllerTest {
                 .build();
         final Options options = Options.builder()
                 .suffix(suffix)
-                .placeholderKey("placeholderKey")
+                .placeholder("placeholder")
                 .build();
         final VendorRequiredFieldV2 vendorRequiredFieldV2 = VendorRequiredFieldV2.builder()
                 .inputCode("ADDRESS_POSTAL_CODE")
-                .inputTitleKey("inputTitleKey")
-                .subTitleKey("subTitleKey")
-                .tooltipKey("tooltipKey")
+                .inputTitle("inputTitle")
+                .subTitle("subTitle")
+                .tooltip("tooltip")
                 .value("value")
                 .fieldType(FieldTypeV2.COUNTRY)
                 .validations(validations)


### PR DESCRIPTION
#### [GOOG-1816](https://appdirect.jira.com/browse/GOOG-1816)

#### Dependencies
NA

#### Description
Inorder to send message to RFS from connector instead of messageKey need to update VendorRequiredFieldV2 payload 
as per https://appdirect.jira.com/browse/PI-23580

#### Manual merge checklist:
- [x] Code Review completed
- [ ] Code coverage
- [ ] QA Validation completed
  - Testrail TestCase/Plan link:
- [ ] Approved by a PI tech lead
- [x] Github checks all green

#### Notification(s)

<img width="1261" alt="Screenshot 2021-12-13 at 4 19 20 PM" src="https://user-images.githubusercontent.com/62536596/145799280-4aa7aae1-7d30-443a-ae3f-18cf336d191f.png">