### PR TITLE
Revert "GOOG-1816: updating VendorRequiredFieldV2 payload "

### DIFF
--- a/src/main/java/com/appdirect/sdk/vendorFields/model/v2/Options.java
+++ b/src/main/java/com/appdirect/sdk/vendorFields/model/v2/Options.java
@@ -11,5 +11,5 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class Options {
     private Suffix suffix;
-    private String placeholder;
+    private String placeholderKey;
 }

--- a/src/main/java/com/appdirect/sdk/vendorFields/model/v2/VendorRequiredFieldV2.java
+++ b/src/main/java/com/appdirect/sdk/vendorFields/model/v2/VendorRequiredFieldV2.java
@@ -11,9 +11,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class VendorRequiredFieldV2 {
     private String inputCode;
-    private String inputTitle;
-    private String subTitle;
-    private String tooltip;
+    private String inputTitleKey;
+    private String subTitleKey;
+    private String tooltipKey;
     private String value;
     private FieldTypeV2 fieldType;
     private Validations validations;

--- a/src/test/java/com/appdirect/sdk/vendorFields/controller/VendorRequiredFieldsControllerTest.java
+++ b/src/test/java/com/appdirect/sdk/vendorFields/controller/VendorRequiredFieldsControllerTest.java
@@ -7,6 +7,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.appdirect.sdk.vendorFields.converter.FlowTypeV2Converter;
+import com.appdirect.sdk.vendorFields.model.v2.FlowTypeV2;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -20,7 +22,6 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.web.bind.WebDataBinder;
 
 import com.appdirect.sdk.vendorFields.converter.FlowTypeConverter;
-import com.appdirect.sdk.vendorFields.converter.FlowTypeV2Converter;
 import com.appdirect.sdk.vendorFields.converter.LocaleConverter;
 import com.appdirect.sdk.vendorFields.converter.OperationTypeConverter;
 import com.appdirect.sdk.vendorFields.handler.VendorRequiredFieldHandler;
@@ -32,7 +33,6 @@ import com.appdirect.sdk.vendorFields.model.OperationType;
 import com.appdirect.sdk.vendorFields.model.VendorRequiredField;
 import com.appdirect.sdk.vendorFields.model.VendorRequiredFieldsResponse;
 import com.appdirect.sdk.vendorFields.model.v2.FieldTypeV2;
-import com.appdirect.sdk.vendorFields.model.v2.FlowTypeV2;
 import com.appdirect.sdk.vendorFields.model.v2.Options;
 import com.appdirect.sdk.vendorFields.model.v2.Suffix;
 import com.appdirect.sdk.vendorFields.model.v2.Validations;
@@ -112,13 +112,13 @@ public class VendorRequiredFieldsControllerTest {
                 .build();
         final Options options = Options.builder()
                 .suffix(suffix)
-                .placeholder("placeholder")
+                .placeholderKey("placeholderKey")
                 .build();
         final VendorRequiredFieldV2 vendorRequiredFieldV2 = VendorRequiredFieldV2.builder()
                 .inputCode("ADDRESS_POSTAL_CODE")
-                .inputTitle("inputTitle")
-                .subTitle("subTitle")
-                .tooltip("tooltip")
+                .inputTitleKey("inputTitleKey")
+                .subTitleKey("subTitleKey")
+                .tooltipKey("tooltipKey")
                 .value("value")
                 .fieldType(FieldTypeV2.COUNTRY)
                 .validations(validations)


### PR DESCRIPTION
Reverts AppDirect/service-integration-sdk#290

We reverted these changes in master(https://github.com/AppDirect/service-integration-sdk/pull/292) however missed reverting in the release-v1